### PR TITLE
所持数の登録・更新機能を実装する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,15 +1,83 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS (and SCSS, if configured) file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
+body {
+  margin: 0;
+  background-color: #f5f5f5;
+  font-family: Arial, sans-serif;
+  color: #222;
+}
+
+.site-header {
+  background-color: #bfbfbf;
+  padding: 12px 0;
+}
+
+.header-inner {
+  width: 960px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo a {
+  text-decoration: none;
+  color: #000;
+  font-weight: bold;
+}
+
+.header-nav {
+  display: flex;
+  gap: 12px;
+}
+
+.header-nav a {
+  text-decoration: none;
+  color: #000;
+  background-color: #eee;
+  border: 1px solid #999;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.main-content {
+  width: 960px;
+  margin: 24px auto;
+  background-color: #fff;
+  min-height: 600px;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.flash-message {
+  margin-bottom: 16px;
+  color: green;
+}
+
+.flash-message.alert {
+  color: red;
+}
+
+.items-page {
+  margin-top: 24px;
+}
+
+.items-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+}
+
+.items-table th,
+.items-table td {
+  border: 1px solid #ccc;
+  padding: 10px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.items-table th {
+  background-color: #e9e9e9;
+}
+
+.items-table input[type="number"] {
+  width: 80px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,15 @@
 class ApplicationController < ActionController::Base
+  protected
+
+  def after_sign_in_path_for(resource)
+    items_path
+  end
+
+  def after_sign_up_path_for(resource)
+    items_path
+  end
+
+  def after_sign_out_path_for(resource_or_scope)
+    root_path
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,4 +2,8 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
 end

--- a/app/controllers/user_items_controller.rb
+++ b/app/controllers/user_items_controller.rb
@@ -1,0 +1,19 @@
+class UserItemsController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    user_item = current_user.user_items.find_or_initialize_by(item_id: params[:item_id])
+
+    if user_item.update(user_item_params)
+      redirect_to items_path, notice: "所持数を更新しました"
+    else
+      redirect_to items_path, alert: "所持数の更新に失敗しました"
+    end
+  end
+
+  private
+
+  def user_item_params
+    params.require(:user_item).permit(:quantity)
+  end
+end

--- a/app/helpers/user_items_helper.rb
+++ b/app/helpers/user_items_helper.rb
@@ -1,0 +1,2 @@
+module UserItemsHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,4 @@
 class Item < ApplicationRecord
+  has_many :user_items, dependent: :destroy
+  has_many :users, through: :user_items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :user_items, dependent: :destroy
+  has_many :items, through: :user_items
 end

--- a/app/models/user_item.rb
+++ b/app/models/user_item.rb
@@ -1,0 +1,7 @@
+class UserItem < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+
+  validates :quantity, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :item_id, uniqueness: { scope: :user_id }
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,7 +3,23 @@
 <% if @items.any? %>
   <ul>
     <% @items.each do |item| %>
-      <li><%= item.name %></li>
+      <li>
+        <strong><%= link_to item.name, item_path(item) %></strong>
+
+        <% if user_signed_in? %>
+          <% user_item = current_user.user_items.find_by(item_id: item.id) %>
+
+          <%= form_with url: user_item_path(item_id: item.id), method: :patch, local: true do |f| %>
+            <div>
+              <%= f.label :quantity, "所持数" %>
+              <%= f.number_field :quantity, value: user_item&.quantity || 0, min: 0, name: "user_item[quantity]" %>
+              <%= f.submit "更新" %>
+            </div>
+          <% end %>
+        <% else %>
+          <p>所持数を更新するにはログインしてください。</p>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,11 @@
+<h1><%= @item.name %></h1>
+
+<div style="margin-top: 24px;">
+  <p>アイテム説明①</p>
+  <div style="width: 300px; height: 120px; background: #e5e5e5; margin-bottom: 16px;"></div>
+
+  <p>アイテム説明②</p>
+  <div style="width: 300px; height: 120px; background: #e5e5e5;"></div>
+</div>
+
+<p style="margin-top: 24px;"><%= link_to "アイテム一覧に戻る", items_path %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,35 @@
   </head>
 
   <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-    <%= yield %>
+    <header class="site-header">
+      <div class="header-inner">
+        <div class="logo">
+          <%= link_to "ロゴ", root_path %>
+        </div>
+
+        <nav class="header-nav">
+          <% if user_signed_in? %>
+            <%= link_to "マイページ", items_path %>
+            <%= link_to "ユーザー情報編集", edit_user_registration_path %>
+            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+          <% else %>
+            <%= link_to "新規登録", new_user_registration_path %>
+            <%= link_to "ログイン", new_user_session_path %>
+          <% end %>
+        </nav>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <% if notice.present? %>
+        <p class="flash-message"><%= notice %></p>
+      <% end %>
+
+      <% if alert.present? %>
+        <p class="flash-message alert"><%= alert %></p>
+      <% end %>
+
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/user_items/update.html.erb
+++ b/app/views/user_items/update.html.erb
@@ -1,0 +1,2 @@
+<h1>UserItems#update</h1>
+<p>Find me in app/views/user_items/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "home#index"
-  resources :items, only: [:index]
+  resources :items, only: %i[index show]
+  patch "user_items", to: "user_items#update", as: :user_item
 end

--- a/db/migrate/20260420093856_create_user_items.rb
+++ b/db/migrate/20260420093856_create_user_items.rb
@@ -1,0 +1,11 @@
+class CreateUserItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_items do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.integer :quantity
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_20_092804) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_20_093856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,16 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_20_092804) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "user_items", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.integer "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_user_items_on_item_id"
+    t.index ["user_id"], name: "index_user_items_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -32,4 +42,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_20_092804) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "user_items", "items"
+  add_foreign_key "user_items", "users"
 end


### PR DESCRIPTION
## 概要
ユーザーごとにアイテムの所持数を登録・更新できる機能を実装しました。

## 実装内容
- UserItemモデルを作成
- user_id / item_id / quantity を保持するようにした
- アイテム一覧画面から所持数を登録・更新できるようにした
- ログイン後はアイテム一覧画面へ遷移するようにした
- 未ログインユーザーには更新フォームを表示しないようにした
- アイテム名から詳細画面へ遷移できるようにした

## 確認事項
- ログインユーザーごとに所持数が保存される
- アイテム一覧画面から所持数を更新できる
- 更新後に値が保持される
- 未ログイン状態では更新フォームが表示されない
- アイテム詳細画面へ遷移できる

close #37