### PR TITLE
共通レイアウトと画面UIを調整する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,63 +1,104 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  background-color: #f5f5f5;
-  font-family: Arial, sans-serif;
+  background-color: #f3f3f3;
   color: #222;
+  font-family: Arial, sans-serif;
+}
+
+a {
+  color: inherit;
 }
 
 .site-header {
-  background-color: #bfbfbf;
-  padding: 12px 0;
+  background-color: #bdbdbd;
+  border-bottom: 1px solid #999;
 }
 
 .header-inner {
   width: 960px;
   margin: 0 auto;
+  padding: 10px 12px;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
-.logo a {
+.header-logo a {
   text-decoration: none;
-  color: #000;
   font-weight: bold;
+  color: #000;
 }
 
 .header-nav {
   display: flex;
-  gap: 12px;
+  gap: 8px;
 }
 
-.header-nav a {
-  text-decoration: none;
-  color: #000;
-  background-color: #eee;
-  border: 1px solid #999;
+.header-button {
+  display: inline-block;
   padding: 4px 10px;
+  border: 1px solid #999;
+  background-color: #efefef;
+  text-decoration: none;
   font-size: 12px;
+  color: #000;
 }
 
-.main-content {
+.page-container {
   width: 960px;
   margin: 24px auto;
+  padding: 24px;
   background-color: #fff;
   min-height: 600px;
-  padding: 24px;
-  box-sizing: border-box;
+  border: 1px solid #ccc;
 }
 
 .flash-message {
-  margin-bottom: 16px;
-  color: green;
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border: 1px solid #ccc;
+  background-color: #f8f8f8;
+}
+
+.flash-message.notice {
+  color: #1b5e20;
 }
 
 .flash-message.alert {
-  color: red;
+  color: #b71c1c;
 }
 
-.items-page {
-  margin-top: 24px;
+.page-title {
+  margin: 0 0 24px;
+  font-size: 32px;
+}
+
+.items-search-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.items-search-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.items-search-form input[type="text"] {
+  width: 180px;
+  padding: 4px 8px;
+}
+
+.items-table-wrapper {
+  background-color: #efefef;
+  padding: 16px;
+  min-height: 360px;
 }
 
 .items-table {
@@ -68,16 +109,71 @@ body {
 
 .items-table th,
 .items-table td {
-  border: 1px solid #ccc;
-  padding: 10px;
+  padding: 10px 12px;
+  border: 1px solid #cfcfcf;
   text-align: left;
   vertical-align: middle;
 }
 
 .items-table th {
-  background-color: #e9e9e9;
+  background-color: #e2e2e2;
+  font-size: 14px;
 }
 
-.items-table input[type="number"] {
-  width: 80px;
+.item-name-link {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+.quantity-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.quantity-form input[type="number"] {
+  width: 72px;
+  padding: 4px 6px;
+}
+
+.simple-button {
+  padding: 4px 10px;
+  border: 1px solid #999;
+  background-color: #efefef;
+  cursor: pointer;
+}
+
+.login-guide {
+  font-size: 13px;
+  color: #555;
+}
+
+.detail-card {
+  width: 540px;
+  border: 1px solid #cfcfcf;
+  background-color: #fff;
+  padding: 24px;
+}
+
+.detail-title {
+  margin: 0 0 24px;
+  text-align: center;
+  font-size: 28px;
+}
+
+.detail-label {
+  margin: 0 0 8px;
+  font-size: 14px;
+}
+
+.detail-box {
+  width: 100%;
+  height: 120px;
+  background-color: #e5e5e5;
+  margin-bottom: 16px;
+}
+
+.back-link {
+  display: inline-block;
+  margin-top: 8px;
 }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,27 +1,55 @@
-<h1>アイテム一覧</h1>
+<h1 class="page-title">必要アイテム数</h1>
 
-<% if @items.any? %>
-  <ul>
-    <% @items.each do |item| %>
-      <li>
-        <strong><%= link_to item.name, item_path(item) %></strong>
-
-        <% if user_signed_in? %>
-          <% user_item = current_user.user_items.find_by(item_id: item.id) %>
-
-          <%= form_with url: user_item_path(item_id: item.id), method: :patch, local: true do |f| %>
-            <div>
-              <%= f.label :quantity, "所持数" %>
-              <%= f.number_field :quantity, value: user_item&.quantity || 0, min: 0, name: "user_item[quantity]" %>
-              <%= f.submit "更新" %>
-            </div>
-          <% end %>
-        <% else %>
-          <p>所持数を更新するにはログインしてください。</p>
-        <% end %>
-      </li>
+<div class="items-search-row">
+  <div>
+    <% if user_signed_in? %>
+      <strong><%= current_user.email %></strong>
+    <% else %>
+      <strong>ゲスト</strong>
     <% end %>
-  </ul>
-<% else %>
-  <p>アイテムが登録されていません。</p>
-<% end %>
+  </div>
+
+  <form class="items-search-form">
+    <label for="item-search">検索</label>
+    <input id="item-search" type="text" placeholder="アイテム名">
+  </form>
+</div>
+
+<div class="items-table-wrapper">
+  <% if @items.any? %>
+    <table class="items-table">
+      <thead>
+        <tr>
+          <th>アイテム名</th>
+          <th>現状数</th>
+          <th>必要数</th>
+          <th>用途</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @items.each do |item| %>
+          <% user_item = current_user&.user_items&.find_by(item_id: item.id) %>
+          <tr>
+            <td>
+              <%= link_to item.name, item_path(item), class: "item-name-link" %>
+            </td>
+            <td>
+              <% if user_signed_in? %>
+                <%= form_with url: user_item_path(item_id: item.id), method: :patch, local: true, class: "quantity-form" do |f| %>
+                  <%= f.number_field :quantity, value: user_item&.quantity || 0, min: 0, name: "user_item[quantity]" %>
+                  <%= f.submit "更新", class: "simple-button" %>
+                <% end %>
+              <% else %>
+                <span class="login-guide">ログインしてください</span>
+              <% end %>
+            </td>
+            <td>5</td>
+            <td>ハイドアウト/タスク</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>アイテムが登録されていません。</p>
+  <% end %>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,11 +1,11 @@
-<h1><%= @item.name %></h1>
+<div class="detail-card">
+  <h1 class="detail-title"><%= @item.name %></h1>
 
-<div style="margin-top: 24px;">
-  <p>アイテム説明①</p>
-  <div style="width: 300px; height: 120px; background: #e5e5e5; margin-bottom: 16px;"></div>
+  <p class="detail-label">アイテム説明①</p>
+  <div class="detail-box"></div>
 
-  <p>アイテム説明②</p>
-  <div style="width: 300px; height: 120px; background: #e5e5e5;"></div>
+  <p class="detail-label">アイテム説明②</p>
+  <div class="detail-box"></div>
+
+  <%= link_to "アイテム一覧に戻る", items_path, class: "back-link" %>
 </div>
-
-<p style="margin-top: 24px;"><%= link_to "アイテム一覧に戻る", items_path %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,26 +13,26 @@
   <body>
     <header class="site-header">
       <div class="header-inner">
-        <div class="logo">
+        <div class="header-logo">
           <%= link_to "ロゴ", root_path %>
         </div>
 
         <nav class="header-nav">
           <% if user_signed_in? %>
-            <%= link_to "マイページ", items_path %>
-            <%= link_to "ユーザー情報編集", edit_user_registration_path %>
-            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+            <%= link_to "マイページ", items_path, class: "header-button" %>
+            <%= link_to "ユーザー情報編集", edit_user_registration_path, class: "header-button" %>
+            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "header-button" %>
           <% else %>
-            <%= link_to "新規登録", new_user_registration_path %>
-            <%= link_to "ログイン", new_user_session_path %>
+            <%= link_to "新規登録", new_user_registration_path, class: "header-button" %>
+            <%= link_to "ログイン", new_user_session_path, class: "header-button" %>
           <% end %>
         </nav>
       </div>
     </header>
 
-    <main class="main-content">
+    <main class="page-container">
       <% if notice.present? %>
-        <p class="flash-message"><%= notice %></p>
+        <p class="flash-message notice"><%= notice %></p>
       <% end %>
 
       <% if alert.present? %>


### PR DESCRIPTION
## 概要
Figmaのレイアウトを参考に、共通レイアウトと各画面のUIを調整しました。

## 実装内容
- 共通ヘッダーを作成
- ログイン前後でヘッダー表示を切り替えるようにした
- アイテム一覧画面を表形式に近いレイアウトへ調整した
- アイテム詳細画面のレイアウトを調整した
- 余白、文字サイズ、配置を整理した

## 確認事項
- 全画面で共通ヘッダーが表示される
- アイテム一覧画面が見やすく整理されている
- アイテム詳細画面が表示される
- 画面遷移でエラーが出ない

close #39