### PR TITLE
必要数表示機能を実装する

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,7 @@
 class Item < ApplicationRecord
   has_many :user_items, dependent: :destroy
   has_many :users, through: :user_items
+
+  validates :name, presence: true
+  validates :required_quantity, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -43,7 +43,7 @@
                 <span class="login-guide">ログインしてください</span>
               <% end %>
             </td>
-            <td>5</td>
+            <td><%= item.required_quantity %></td>
             <td>ハイドアウト/タスク</td>
           </tr>
         <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,8 @@
 <div class="detail-card">
   <h1 class="detail-title"><%= @item.name %></h1>
 
+  <p class="detail-label">必要数: <%= @item.required_quantity %></p>
+
   <p class="detail-label">アイテム説明①</p>
   <div class="detail-box"></div>
 

--- a/db/migrate/20260421043953_add_required_quantity_to_items.rb
+++ b/db/migrate/20260421043953_add_required_quantity_to_items.rb
@@ -1,0 +1,5 @@
+class AddRequiredQuantityToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :required_quantity, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_20_093856) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_21_043953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_20_093856) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "required_quantity"
   end
 
   create_table "user_items", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,11 @@
-Item.find_or_create_by!(name: "Salewa first aid kit")
-Item.find_or_create_by!(name: "Gas analyzer")
-Item.find_or_create_by!(name: "Spark plug")
+Item.find_or_create_by!(name: "Salewa first aid kit") do |item|
+  item.required_quantity = 3
+end
+
+Item.find_or_create_by!(name: "Gas analyzer") do |item|
+  item.required_quantity = 2
+end
+
+Item.find_or_create_by!(name: "Spark plug") do |item|
+  item.required_quantity = 5
+end


### PR DESCRIPTION
## 概要
各アイテムに必要数を表示できる機能を実装しました。

## 実装内容
- Itemモデルに required_quantity カラムを追加
- seedデータに必要数を追加
- アイテム一覧画面に必要数を表示
- アイテム詳細画面に必要数を表示

## 確認事項
- 各アイテムに必要数が保存される
- アイテム一覧画面で必要数が表示される
- アイテム詳細画面で必要数が表示される
- 画面遷移でエラーが出ない

close #23