### PR TITLE
所持数と必要数の比較表示機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,12 @@
 class ItemsController < ApplicationController
   def index
     @items = Item.all
+
+    if user_signed_in?
+      @user_items_by_item_id = current_user.user_items.index_by(&:item_id)
+    else
+      @user_items_by_item_id = {}
+    end
   end
 
   def show

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -23,27 +23,46 @@
           <th>アイテム名</th>
           <th>現状数</th>
           <th>必要数</th>
+          <th>比較結果</th>
           <th>用途</th>
         </tr>
       </thead>
       <tbody>
         <% @items.each do |item| %>
-          <% user_item = current_user&.user_items&.find_by(item_id: item.id) %>
+          <% user_item = @user_items_by_item_id[item.id] %>
+          <% current_quantity = user_item&.quantity || 0 %>
+          <% required_quantity = item.required_quantity || 0 %>
+
           <tr>
             <td>
               <%= link_to item.name, item_path(item), class: "item-name-link" %>
             </td>
+
             <td>
               <% if user_signed_in? %>
                 <%= form_with url: user_item_path(item_id: item.id), method: :patch, local: true, class: "quantity-form" do |f| %>
-                  <%= f.number_field :quantity, value: user_item&.quantity || 0, min: 0, name: "user_item[quantity]" %>
+                  <%= f.number_field :quantity, value: current_quantity, min: 0, name: "user_item[quantity]" %>
                   <%= f.submit "更新", class: "simple-button" %>
                 <% end %>
               <% else %>
                 <span class="login-guide">ログインしてください</span>
               <% end %>
             </td>
-            <td><%= item.required_quantity %></td>
+
+            <td><%= required_quantity %></td>
+
+            <td>
+              <% if user_signed_in? %>
+                <% if current_quantity >= required_quantity %>
+                  必要数達成
+                <% else %>
+                  まだ必要
+                <% end %>
+              <% else %>
+                ログインしてください
+              <% end %>
+            </td>
+
             <td>ハイドアウト/タスク</td>
           </tr>
         <% end %>


### PR DESCRIPTION
## 概要
所持数と必要数の比較表示機能を実装しました。

## 実装内容
- アイテム一覧画面に「比較結果」列を追加
- ログインユーザーの所持数と必要数を比較して表示
- 所持数が必要数未満の場合は「まだ必要」と表示
- 所持数が必要数以上の場合は「必要数達成」と表示
- required_quantity が nil の場合でも画面が落ちないように修正

## 確認事項
- 一覧画面で所持数と必要数の比較結果が表示される
- 所持数更新後に比較結果が切り替わる
- 画面遷移でエラーが出ない

close #25