### PR TITLE
アイテム初期データ登録

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,11 @@ end
 Item.find_or_create_by!(name: "Spark plug") do |item|
   item.required_quantity = 5
 end
+
+Item.find_or_create_by!(name: "Screw nuts") do |item|
+  item.required_quantity = 4
+end
+
+Item.find_or_create_by!(name: "Bolts") do |item|
+  item.required_quantity = 2
+end


### PR DESCRIPTION
## 概要
MVPで使用するアイテムの初期データを登録しました。

## 実装内容
- db/seeds.rb にアイテム初期データを追加
- required_quantity を含めた seed データを登録
- 一覧画面で参照できることを確認

## 確認事項
- rails db:seed でアイテムデータが登録される
- /items でアイテム一覧が表示される
- 必要数が表示される
- 検索機能と干渉しない

close #29