### PR TITLE
アイテム詳細画面の必要数表示を修正

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,7 +1,7 @@
 <div class="detail-card">
   <h1 class="detail-title"><%= @item.name %></h1>
 
-  <p class="detail-label">必要数: <%= @item.required_quantity %></p>
+  <p class="detail-label">必要数: <%= @item.total_required_quantity %></p>
 
   <p class="detail-label">アイテム説明①</p>
   <div class="detail-box"></div>


### PR DESCRIPTION
## 概要

本番環境でアイテム詳細画面にアクセスした際に発生していたエラーを修正しました。

## 変更内容

- `app/views/items/show.html.erb` の必要数表示を修正
- 廃止済みの `@item.required_quantity` 参照を削除
- `item_tasks` / `item_hideouts` から合算する `@item.total_required_quantity` を使用するよう変更

## 確認内容

- `grep -R "required_quantity" -n app/views app/controllers app/models` で、詳細画面に古い `@item.required_quantity` 参照が残っていないことを確認
- アイテム詳細画面で使用する必要数が `total_required_quantity` に変更されていることを確認

## 関連 issue

#28 本番環境の動作確認中に発見