### PR TITLE
アイテム詳細画面に用途別必要数を表示

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,8 +16,16 @@ class Item < ApplicationRecord
     end
   }
 
+  def task_required_quantity
+    item_tasks.sum(:required_quantity)
+  end
+
+  def hideout_required_quantity
+    item_hideouts.sum(:required_quantity)
+  end
+
   def total_required_quantity
-    item_tasks.sum(:required_quantity) + item_hideouts.sum(:required_quantity)
+    task_required_quantity + hideout_required_quantity
   end
 
   def usage_labels

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,13 +1,41 @@
 <div class="detail-card">
   <h1 class="detail-title"><%= @item.name %></h1>
 
-  <p class="detail-label">必要数: <%= @item.total_required_quantity %></p>
+  <p class="detail-label">必要数合計: <%= @item.total_required_quantity %></p>
+  <p class="detail-label">タスク必要数: <%= @item.task_required_quantity %></p>
+  <p class="detail-label">ハイドアウト必要数: <%= @item.hideout_required_quantity %></p>
 
-  <p class="detail-label">アイテム説明①</p>
-  <div class="detail-box"></div>
+  <p class="detail-label">タスクで使用</p>
+  <div class="detail-box">
+    <% if @item.item_tasks.any? %>
+      <ul>
+        <% @item.item_tasks.each do |item_task| %>
+          <li>
+            <%= item_task.task.name %>:
+            <%= item_task.required_quantity %>個
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p>なし</p>
+    <% end %>
+  </div>
 
-  <p class="detail-label">アイテム説明②</p>
-  <div class="detail-box"></div>
+  <p class="detail-label">ハイドアウトで使用</p>
+  <div class="detail-box">
+    <% if @item.item_hideouts.any? %>
+      <ul>
+        <% @item.item_hideouts.each do |item_hideout| %>
+          <li>
+            <%= item_hideout.hideout.name %>:
+            <%= item_hideout.required_quantity %>個
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p>なし</p>
+    <% end %>
+  </div>
 
   <%= link_to "アイテム一覧に戻る", items_path, class: "back-link" %>
 </div>


### PR DESCRIPTION
## 概要

アイテム詳細画面に、登録済みのタスク・ハイドアウト用途を表示するようにしました。

## 変更内容

- アイテム詳細画面に必要数合計を表示
- タスク必要数を表示
- ハイドアウト必要数を表示
- タスクで使用する場合、タスク名と必要数を表示
- ハイドアウトで使用する場合、ハイドアウト名と必要数を表示
- 用途がない場合は「なし」と表示
- `items.required_quantity` ではなく、`item_tasks` / `item_hideouts` のデータを使用

## 確認内容

- アイテム詳細画面で必要数合計が表示されること
- タスクで使用するアイテムに、タスク名と必要数が表示されること
- ハイドアウトで使用するアイテムに、ハイドアウト名と必要数が表示されること
- 用途がない場合でもエラーにならず「なし」と表示されること
- `@item.required_quantity` の参照が残っていないこと

## 関連 issue

#28 本番環境の動作確認中に改善