### PR TITLE
タスク一覧画面を作成

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,9 @@
+class TasksController < ApplicationController
+  def index
+    @tasks = Task.order(:name)
+  end
+
+  def show
+    @task = Task.find(params[:id])
+  end
+end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,24 @@
+<div class="page-header">
+  <h1>タスク一覧</h1>
+</div>
+
+<% if @tasks.any? %>
+  <table class="items-table">
+    <thead>
+      <tr>
+        <th>タスク名</th>
+        <th>詳細</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @tasks.each do |task| %>
+        <tr>
+          <td><%= task.name %></td>
+          <td><%= link_to "詳細", task_path(task) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>タスクが登録されていません。</p>
+<% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,7 @@
+<div class="detail-card">
+  <h1 class="detail-title"><%= @task.name %></h1>
+
+  <p class="detail-label">タスク詳細画面は作成中です。</p>
+
+  <%= link_to "タスク一覧に戻る", tasks_path, class: "back-link" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
 
   root "home#index"
   resources :items, only: %i[index show]
+  resources :tasks, only: %i[index show]
   patch "user_items", to: "user_items#update", as: :user_item
 end


### PR DESCRIPTION
## 概要

タスク一覧画面を追加しました。

## 変更内容

- tasks のルーティングを追加
- TasksController を作成
- タスク一覧画面を作成
- タスク詳細画面の最小表示を作成

## 確認内容

- `/tasks` にアクセスできること
- タスク名が一覧表示されること
- 詳細リンクから `/tasks/:id` に遷移できること