### PR TITLE
タスク詳細画面を作成

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,6 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = Task.find(params[:id])
+    @task = Task.includes(item_tasks: :item).find(params[:id])
   end
 end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,7 +1,13 @@
 <div class="detail-card">
   <h1 class="detail-title"><%= @task.name %></h1>
 
-  <p class="detail-label">タスク詳細画面は作成中です。</p>
+  <p class="detail-label">必要アイテム数: <%= @task.item_tasks.count %>件</p>
+  <p class="detail-label">必要個数合計: <%= @task.item_tasks.sum(:required_quantity) %>個</p>
+
+  <p class="detail-label">タスク情報</p>
+  <div class="detail-box">
+    <p>タスク名: <%= @task.name %></p>
+  </div>
 
   <%= link_to "タスク一覧に戻る", tasks_path, class: "back-link" %>
 </div>


### PR DESCRIPTION
## 概要

タスク詳細画面を作成しました。

## 変更内容

- TasksController#show で item_tasks と item を含めて取得するように変更
- タスク詳細画面にタスク名を表示
- 必要アイテム数を表示
- 必要個数合計を表示
- タスク一覧へ戻るリンクを追加

## 確認内容

- `/tasks/:id` にアクセスできること
- タスク名が表示されること
- 必要アイテム数が表示されること
- 必要個数合計が表示されること
- タスク一覧へ戻れること

close #57