### PR TITLE
タスク詳細画面に必要アイテム一覧を表示

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,5 +5,6 @@ class TasksController < ApplicationController
 
   def show
     @task = Task.includes(item_tasks: :item).find(params[:id])
+    @item_tasks = @task.item_tasks.sort_by { |item_task| item_task.item.name }
   end
 end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,9 +4,20 @@
   <p class="detail-label">必要アイテム数: <%= @task.item_tasks.count %>件</p>
   <p class="detail-label">必要個数合計: <%= @task.item_tasks.sum(:required_quantity) %>個</p>
 
-  <p class="detail-label">タスク情報</p>
+  <p class="detail-label">必要アイテム一覧</p>
   <div class="detail-box">
-    <p>タスク名: <%= @task.name %></p>
+    <% if @item_tasks.any? %>
+      <ul>
+        <% @item_tasks.each do |item_task| %>
+          <li>
+            <%= link_to item_task.item.name, item_path(item_task.item) %>
+            ：<%= item_task.required_quantity %>個
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p>必要アイテムは登録されていません。</p>
+    <% end %>
   </div>
 
   <%= link_to "タスク一覧に戻る", tasks_path, class: "back-link" %>


### PR DESCRIPTION
## 概要

タスク詳細画面に必要アイテム一覧を表示しました。

## 変更内容

- TasksController#show で必要アイテム一覧を扱えるように変更
- タスク詳細画面に必要アイテム一覧を表示
- 各アイテム詳細画面へのリンクを追加
- 必要アイテム未登録時のメッセージを追加

## 確認内容

- `/tasks/:id` にアクセスできること
- 必要アイテム数が表示されること
- 必要個数合計が表示されること
- 必要アイテム一覧が表示されること
- アイテム詳細画面へ遷移できること

close #58