### PR TITLE
管理者権限を追加

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,4 @@
+class Admin::BaseController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin!
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,3 @@
+class Admin::DashboardController < Admin::BaseController
+  def index; end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,10 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     root_path
   end
+
+  def require_admin!
+    return if user_signed_in? && current_user.admin?
+
+    redirect_to root_path, alert: "管理者のみアクセスできます。"
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,12 @@
+<div class="detail-card">
+  <h1 class="detail-title">管理画面</h1>
+
+  <p class="detail-label">管理者専用ページです。</p>
+
+  <div class="detail-box">
+    <p>今後ここに管理者向け機能を追加していきます。</p>
+    <p>例: アイテム編集、タスク編集、データ追加</p>
+  </div>
+
+  <%= link_to "アイテム一覧に戻る", items_path, class: "back-link" %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,11 @@
         <nav class="header-nav">
           <% if user_signed_in? %>
             <%= link_to "マイページ", items_path, class: "header-button" %>
+
+            <% if current_user.admin? %>
+              <%= link_to "管理画面", admin_root_path, class: "header-button" %>
+            <% end %>
+
             <%= link_to "ユーザー情報編集", edit_user_registration_path, class: "header-button" %>
             <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "header-button" %>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,9 @@ Rails.application.routes.draw do
   resources :items, only: %i[index show]
   resources :tasks, only: %i[index show]
   patch "user_items", to: "user_items#update", as: :user_item
+
+  namespace :admin do
+    root "dashboard#index"
+    get "dashboard", to: "dashboard#index"
+  end
 end

--- a/db/migrate/20260509102451_add_admin_to_users.rb
+++ b/db/migrate/20260509102451_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_24_145413) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_09_102451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_24_145413) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要

軽い管理者機能として、管理者権限を追加しました。

## 変更内容

- users テーブルに admin カラムを追加
- 管理者判定用の `require_admin!` を追加
- 管理者専用の管理画面を追加
- 管理者のみヘッダーに管理画面リンクを表示
- 一般ユーザーは管理画面にアクセスできないように制御

## 確認内容

- admin=true のユーザーでログインすると管理画面リンクが表示されること
- 管理者が `/admin` にアクセスできること
- 一般ユーザーでは管理画面リンクが表示されないこと
- 一般ユーザーが `/admin` にアクセスするとトップページにリダイレクトされること

close #59