### PR TITLE
レベル帯ごとの必要アイテム一覧を表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,18 @@
 class ItemsController < ApplicationController
   def index
     @q = params[:q].to_s.strip
+    @selected_level_range = params[:level_range].to_s.strip
+    @level_ranges = [10, 20, 30, 40, 50, 60, 70]
 
     @items = Item
       .search_by_name(@q)
-      .includes(:item_tasks, :tasks, :item_hideouts, :hideouts)
+      .includes(item_tasks: :task, item_hideouts: :hideout)
       .order(:name)
+
+    if @selected_level_range.present?
+      level = @selected_level_range.to_i
+      @items = @items.select { |item| item.total_required_quantity_up_to_level(level).positive? }
+    end
 
     if user_signed_in?
       @user_items_by_item_id = current_user.user_items.index_by(&:item_id)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -34,4 +34,12 @@ class Item < ApplicationRecord
     labels << "ハイドアウト" if item_hideouts.exists?
     labels
   end
+
+  def task_required_quantity_up_to_level(level)
+    item_tasks.joins(:task).where(tasks: { level: ..level }).sum(:required_quantity)
+  end
+
+  def total_required_quantity_up_to_level(level)
+    task_required_quantity_up_to_level(level) + hideout_required_quantity
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -12,6 +12,12 @@
   <%= form_with url: items_path, method: :get, local: true, class: "items-search-form" do %>
     <%= label_tag :q, "検索" %>
     <%= text_field_tag :q, @q, id: "item-search", placeholder: "アイテム名" %>
+
+    <%= label_tag :level_range, "必要レベル帯" %>
+    <%= select_tag :level_range,
+        options_for_select([["すべて", ""]] + @level_ranges.map { |level| ["Lv#{level}まで", level] }, @selected_level_range) %>
+
+    <%= submit_tag "絞り込む", class: "simple-button" %>
   <% end %>
 </div>
 
@@ -31,7 +37,12 @@
         <% @items.each do |item| %>
           <% user_item = @user_items_by_item_id[item.id] %>
           <% current_quantity = user_item&.quantity || 0 %>
-          <% required_quantity = item.total_required_quantity %>
+          <% required_quantity =
+               if @selected_level_range.present?
+                 item.total_required_quantity_up_to_level(@selected_level_range.to_i)
+               else
+                 item.total_required_quantity
+               end %>
           <% usage_text = item.usage_labels.join("/") %>
 
           <tr>


### PR DESCRIPTION
## 概要

アイテム一覧でレベル帯ごとの必要アイテムを確認できるようにしました。

## 変更内容

- ItemsController#index に必要レベル帯の絞り込みを追加
- Item モデルにレベル帯ごとの必要数を計算するメソッドを追加
- アイテム一覧画面に必要レベル帯の選択欄を追加
- レベル帯に応じた必要数を表示できるように変更

## 確認内容

- `/items` にアクセスできること
- 必要レベル帯の選択欄が表示されること
- Lv10まで / Lv20まで などで絞り込みできること
- 絞り込み後、該当アイテムのみ表示されること
- 必要数がレベル帯に応じて変わること

close #62