### PR TITLE
アイテム一覧に関連タスク名とハイドアウト名を表示

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -42,4 +42,19 @@ class Item < ApplicationRecord
   def total_required_quantity_up_to_level(level)
     task_required_quantity_up_to_level(level) + hideout_required_quantity
   end
+
+  def related_task_names_up_to_level(level = nil)
+    scope = tasks.distinct.order(:name)
+    scope = scope.where(level: ..level) if level.present?
+    scope.pluck(:name)
+  end
+
+  def related_hideout_names
+    hideouts.distinct.order(:name).pluck(:name)
+  end
+
+  def usage_detail_text(level = nil)
+    names = related_task_names_up_to_level(level) + related_hideout_names
+    names.uniq.join(", ")
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -37,13 +37,15 @@
         <% @items.each do |item| %>
           <% user_item = @user_items_by_item_id[item.id] %>
           <% current_quantity = user_item&.quantity || 0 %>
+          <% selected_level = @selected_level_range.present? ? @selected_level_range.to_i : nil %>
           <% required_quantity =
-               if @selected_level_range.present?
-                 item.total_required_quantity_up_to_level(@selected_level_range.to_i)
+               if selected_level.present?
+                 item.total_required_quantity_up_to_level(selected_level)
                else
                  item.total_required_quantity
                end %>
-          <% usage_text = item.usage_labels.join("/") %>
+          <% usage_text = item.usage_labels.join(" / ") %>
+          <% usage_detail_text = item.usage_detail_text(selected_level) %>
 
           <tr>
             <td>
@@ -75,7 +77,14 @@
               <% end %>
             </td>
 
-            <td><%= usage_text.presence || "-" %></td>
+            <td>
+              <% if usage_text.present? %>
+                <div><%= usage_text %></div>
+                <div><%= usage_detail_text %></div>
+              <% else %>
+                -
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
## 概要

アイテム一覧の用途欄に、関連するタスク名とハイドアウト名を表示できるようにしました。

## 変更内容

- Item モデルに関連タスク名を取得するメソッドを追加
- Item モデルに関連ハイドアウト名を取得するメソッドを追加
- Item モデルに用途詳細表示用のメソッドを追加
- アイテム一覧画面の用途欄に用途種別と関連名を表示するように変更
- レベル帯指定時は、そのレベル帯までのタスク名のみ表示するように変更

## 確認内容

- `/items` にアクセスできること
- 用途欄に「タスク / ハイドアウト」が表示されること
- 関連するタスク名・ハイドアウト名が表示されること
- レベル帯指定時は、そのレベル帯までのタスク名のみ表示されること
- ハイドアウト名は常に表示されること

close #64