### PR TITLE
アイテム一覧にソート機能を追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,17 +2,27 @@ class ItemsController < ApplicationController
   def index
     @q = params[:q].to_s.strip
     @selected_level_range = params[:level_range].to_s.strip
+    @selected_sort = params[:sort].to_s.strip
     @level_ranges = [10, 20, 30, 40, 50, 60, 70]
+    @sort_options = [
+      ["アイテム名順", "name"],
+      ["必要数順", "required_quantity"],
+      ["タスク必要数順", "task_required_quantity"],
+      ["ハイドアウト必要数順", "hideout_required_quantity"]
+    ]
 
     @items = Item
       .search_by_name(@q)
       .includes(item_tasks: :task, item_hideouts: :hideout)
       .order(:name)
+      .to_a
 
     if @selected_level_range.present?
       level = @selected_level_range.to_i
       @items = @items.select { |item| item.total_required_quantity_up_to_level(level).positive? }
     end
+
+    @items = sort_items(@items)
 
     if user_signed_in?
       @user_items_by_item_id = current_user.user_items.index_by(&:item_id)
@@ -23,5 +33,37 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.includes(:item_tasks, :tasks, :item_hideouts, :hideouts).find(params[:id])
+  end
+
+  private
+
+  def sort_items(items)
+    case @selected_sort
+    when "required_quantity"
+      items.sort_by do |item|
+        selected_level = @selected_level_range.present? ? @selected_level_range.to_i : nil
+        quantity =
+          if selected_level.present?
+            item.total_required_quantity_up_to_level(selected_level)
+          else
+            item.total_required_quantity
+          end
+        [-quantity, item.name]
+      end
+    when "task_required_quantity"
+      items.sort_by do |item|
+        quantity =
+          if @selected_level_range.present?
+            item.task_required_quantity_up_to_level(@selected_level_range.to_i)
+          else
+            item.task_required_quantity
+          end
+        [-quantity, item.name]
+      end
+    when "hideout_required_quantity"
+      items.sort_by { |item| [-item.hideout_required_quantity, item.name] }
+    else
+      items.sort_by(&:name)
+    end
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -17,6 +17,10 @@
     <%= select_tag :level_range,
         options_for_select([["すべて", ""]] + @level_ranges.map { |level| ["Lv#{level}まで", level] }, @selected_level_range) %>
 
+    <%= label_tag :sort, "並び順" %>
+    <%= select_tag :sort,
+        options_for_select(@sort_options, @selected_sort.presence || "name") %>
+
     <%= submit_tag "絞り込む", class: "simple-button" %>
   <% end %>
 </div>


### PR DESCRIPTION
## 概要

アイテム一覧で必要なアイテムを探しやすくするため、ソート機能を追加しました。

## 変更内容

- ItemsController#index に sort パラメータを追加
- アイテム名順の並び替えを追加
- 必要数順の並び替えを追加
- タスク必要数順の並び替えを追加
- ハイドアウト必要数順の並び替えを追加
- アイテム一覧画面に並び順の選択欄を追加

## 確認内容

- `/items` にアクセスできること
- 並び順の選択欄が表示されること
- アイテム名順で並び替えできること
- 必要数順で並び替えできること
- タスク必要数順で並び替えできること
- ハイドアウト必要数順で並び替えできること
- レベル帯絞り込みと組み合わせて使えること