### PR TITLE
Feature/task completion check

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   def index
     @selected_trader = params[:trader].to_s.strip
     @selected_level = params[:level].to_s.strip
+    @selected_status = params[:status].to_s.strip
 
     @traders = Task.where.not(trader: [nil, ""]).distinct.order(:trader).pluck(:trader)
     @levels = Task.distinct.order(:level).pluck(:level)
@@ -9,6 +10,21 @@ class TasksController < ApplicationController
     @tasks = Task.order(:name)
     @tasks = @tasks.where(trader: @selected_trader) if @selected_trader.present?
     @tasks = @tasks.where(level: @selected_level.to_i) if @selected_level.present?
+
+    if user_signed_in?
+      @user_tasks_by_task_id = current_user.user_tasks.index_by(&:task_id)
+
+      case @selected_status
+      when "completed"
+        completed_task_ids = current_user.user_tasks.where(completed: true).pluck(:task_id)
+        @tasks = @tasks.where(id: completed_task_ids)
+      when "incomplete"
+        completed_task_ids = current_user.user_tasks.where(completed: true).pluck(:task_id)
+        @tasks = @tasks.where.not(id: completed_task_ids)
+      end
+    else
+      @user_tasks_by_task_id = {}
+    end
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
 
     @tasks = Task.order(:name)
     @tasks = @tasks.where(trader: @selected_trader) if @selected_trader.present?
-    @tasks = @tasks.where(level: @selected_level.to_i) if @selected_level.present?
+    @tasks = @tasks.where(level: ..@selected_level.to_i) if @selected_level.present?
 
     if user_signed_in?
       @user_tasks_by_task_id = current_user.user_tasks.index_by(&:task_id)

--- a/app/controllers/user_tasks_controller.rb
+++ b/app/controllers/user_tasks_controller.rb
@@ -1,0 +1,18 @@
+class UserTasksController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    task = Task.find(params[:task_id])
+    user_task = current_user.user_tasks.find_or_initialize_by(task: task)
+    user_task.completed = ActiveModel::Type::Boolean.new.cast(user_task_params[:completed])
+    user_task.save!
+
+    redirect_to tasks_path(trader: params[:trader], level: params[:level], status: params[:status]), notice: "タスク進行状況を更新しました。"
+  end
+
+  private
+
+  def user_task_params
+    params.require(:user_task).permit(:completed)
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,8 @@
 class Task < ApplicationRecord
   has_many :item_tasks, dependent: :destroy
   has_many :items, through: :item_tasks
+  has_many :user_tasks, dependent: :destroy
+  has_many :users, through: :user_tasks
 
   validates :name, presence: true, uniqueness: true
   validates :trader, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
 
   has_many :user_items, dependent: :destroy
   has_many :items, through: :user_items
+  has_many :user_tasks, dependent: :destroy
+  has_many :tasks, through: :user_tasks
 end

--- a/app/models/user_task.rb
+++ b/app/models/user_task.rb
@@ -1,0 +1,6 @@
+class UserTask < ApplicationRecord
+  belongs_to :user
+  belongs_to :task
+
+  validates :task_id, uniqueness: { scope: :user_id }
+end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,6 +17,12 @@
     </div>
 
     <div class="field">
+      <%= label_tag :status, "進行状況で絞り込み" %>
+      <%= select_tag :status,
+          options_for_select([["すべて", ""], ["完了", "completed"], ["未完了", "incomplete"]], @selected_status) %>
+    </div>
+
+    <div class="field">
       <%= submit_tag "絞り込む", class: "header-button" %>
     </div>
   <% end %>
@@ -29,14 +35,28 @@
         <th>タスク名</th>
         <th>トレーダー</th>
         <th>必要レベル</th>
+        <th>進行状況</th>
       </tr>
     </thead>
     <tbody>
       <% @tasks.each do |task| %>
+        <% user_task = @user_tasks_by_task_id[task.id] %>
+        <% completed = user_task&.completed || false %>
+
         <tr>
           <td><%= link_to task.name, task_path(task) %></td>
           <td><%= task.trader %></td>
           <td><%= task.level %></td>
+          <td>
+            <% if user_signed_in? %>
+              <%= form_with url: user_task_path(task_id: task.id, trader: @selected_trader, level: @selected_level, status: @selected_status), method: :patch, local: true do |f| %>
+                <%= f.hidden_field :completed, value: completed ? "0" : "1", name: "user_task[completed]" %>
+                <%= f.submit(completed ? "完了" : "未完了", class: "simple-button") %>
+              <% end %>
+            <% else %>
+              ログインしてください
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :items, only: %i[index show]
   resources :tasks, only: %i[index show]
   patch "user_items", to: "user_items#update", as: :user_item
+  patch "user_tasks", to: "user_tasks#update", as: :user_task
 
   namespace :admin do
     root "dashboard#index"

--- a/db/migrate/20260511172651_create_user_tasks.rb
+++ b/db/migrate/20260511172651_create_user_tasks.rb
@@ -1,0 +1,13 @@
+class CreateUserTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_tasks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :task, null: false, foreign_key: true
+      t.boolean :completed, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :user_tasks, [:user_id, :task_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_11_163300) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_11_172651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_11_163300) do
     t.index ["user_id"], name: "index_user_items_on_user_id"
   end
 
+  create_table "user_tasks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "task_id", null: false
+    t.boolean "completed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_user_tasks_on_task_id"
+    t.index ["user_id", "task_id"], name: "index_user_tasks_on_user_id_and_task_id", unique: true
+    t.index ["user_id"], name: "index_user_tasks_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -83,4 +94,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_11_163300) do
   add_foreign_key "item_tasks", "tasks"
   add_foreign_key "user_items", "items"
   add_foreign_key "user_items", "users"
+  add_foreign_key "user_tasks", "tasks"
+  add_foreign_key "user_tasks", "users"
 end


### PR DESCRIPTION
## 概要

ユーザーごとにタスク進行状況を管理できるように、チェック機能を追加しました。

## 変更内容

- user_tasks テーブルを追加
- User / Task / UserTask の関連を追加
- user_tasks 更新用ルーティングを追加
- タスク一覧画面に進行状況列を追加
- 完了 / 未完了を切り替えられるように変更
- 進行状況での絞り込みを追加
- 絞り込み条件を維持したまま更新できるように変更
- 必要レベルの絞り込みを累積表示に修正

## 確認内容

- `/tasks` にアクセスできること
- タスク一覧に進行状況列が表示されること
- ログイン時に完了 / 未完了を切り替えられること
- 完了 / 未完了で絞り込みできること
- トレーダー、必要レベル、進行状況を組み合わせて絞り込めること
- 必要レベル絞り込みが累積表示になっていること
- 更新後も絞り込み条件が維持されること

close #65