### PR TITLE
Feature/guest login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,11 @@ class ApplicationController < ActionController::Base
   protected
 
   def after_sign_in_path_for(resource)
-    items_path
+    root_path
   end
 
   def after_sign_up_path_for(resource)
-    items_path
+    root_path
   end
 
   def after_sign_out_path_for(resource_or_scope)
@@ -14,8 +14,8 @@ class ApplicationController < ActionController::Base
   end
 
   def require_admin!
-    return if user_signed_in? && current_user.admin?
-
-    redirect_to root_path, alert: "管理者のみアクセスできます。"
+    unless user_signed_in? && current_user.admin?
+      redirect_to root_path, alert: "管理者のみアクセスできます。"
+    end
   end
 end

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,19 @@
+<div class="detail-card">
+  <h1 class="detail-title">パスワード再設定</h1>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <div class="field">
+      <%= f.label :email, "メールアドレス" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "再設定メールを送信", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 16px;">
+    <p><%= link_to "ログイン画面に戻る", new_user_session_path %></p>
+    <p><%= link_to "新規登録はこちら", new_user_registration_path %></p>
+  </div>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,48 @@
+<div class="detail-card">
+  <h1 class="detail-title">ユーザー情報編集</h1>
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <div class="field">
+      <%= f.label :email, "メールアドレス" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password, "新しいパスワード" %><br />
+      <small>変更しない場合は空欄のままにしてください</small><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation, "新しいパスワード（確認用）" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :current_password, "現在のパスワード" %><br />
+      <small>変更を保存するために現在のパスワードを入力してください</small><br />
+      <%= f.password_field :current_password, autocomplete: "current-password" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "更新する", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <hr style="margin: 24px 0;">
+
+  <h2>アカウント削除</h2>
+  <p>退会する場合はこちら</p>
+
+  <div class="actions">
+    <%= button_to "アカウントを削除する",
+                  registration_path(resource_name),
+                  data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" },
+                  method: :delete,
+                  class: "header-button" %>
+  </div>
+
+  <div class="field" style="margin-top: 16px;">
+    <%= link_to "マイページに戻る", items_path %>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,29 @@
+<div class="detail-card">
+  <h1 class="detail-title">新規登録</h1>
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <div class="field">
+      <%= f.label :email, "メールアドレス" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password, "パスワード" %><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation, "パスワード確認" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "登録する", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 16px;">
+    <p><%= link_to "ログインはこちら", new_user_session_path %></p>
+    <p><%= link_to "パスワードをお忘れですか？", new_user_password_path %></p>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,31 @@
+<div class="detail-card">
+  <h1 class="detail-title">ログイン</h1>
+
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="field">
+      <%= f.label :email, "メールアドレス" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password, "パスワード" %><br />
+      <%= f.password_field :password, autocomplete: "current-password" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="field">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me, "ログイン状態を保持する" %>
+      </div>
+    <% end %>
+
+    <div class="actions">
+      <%= f.submit "ログイン", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 16px;">
+    <p><%= link_to "新規登録はこちら", new_user_registration_path %></p>
+    <p><%= link_to "パスワードをお忘れですか？", new_user_password_path %></p>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,14 +1,39 @@
-<h1>EFT Item Manager</h1>
+<div class="detail-card">
+  <h1 class="detail-title">EFT Item Manager</h1>
 
-<p>トップページです。</p>
+  <% if user_signed_in? %>
+    <p>
+      Escape from Tarkov で必要なアイテムを、
+      タスク・ハイドアウト・所持数とあわせて管理できるアプリです。
+    </p>
+    <p>
+      必要数と現在の所持数を比較しながら、
+      売ってよいアイテムと残しておくべきアイテムを分かりやすく確認できます。
+    </p>
+    <p>
+      ログイン中：<%= current_user.email %>
+    </p>
 
-<p><%= link_to "アイテム一覧", items_path %></p>
+    <div class="field" style="margin-top: 16px;">
+      <p><%= link_to "アイテム一覧", items_path %></p>
+      <p><%= link_to "タスク一覧", tasks_path %></p>
+      <p><%= link_to "ユーザー情報編集", edit_user_registration_path %></p>
+      <p><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %></p>
+    </div>
+  <% else %>
+    <p>
+      Escape from Tarkov で必要なアイテムを、
+      タスク・ハイドアウト・所持数とあわせて管理できるアプリです。
+    </p>
+    <p>
+      必要数と現在の所持数を比較しながら、
+      売ってよいアイテムと残しておくべきアイテムを分かりやすく確認できます。
+    </p>
 
-<% if user_signed_in? %>
-  <p>ログイン中: <%= current_user.email %></p>
-  <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
-<% else %>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <br>
-  <%= link_to "ログイン", new_user_session_path %>
-<% end %>
+    <div class="field" style="margin-top: 16px;">
+      <p><%= link_to "アイテム一覧", items_path %></p>
+      <p><%= link_to "新規登録", new_user_registration_path %></p>
+      <p><%= link_to "ログイン", new_user_session_path %></p>
+    </div>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require_relative "boot"
 
 require "rails"
-# Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
@@ -12,31 +11,17 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-# require "rails/test_unit/railtie"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module App
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
-
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
 
-    # Don't generate system test files.
     config.generators.system_tests = nil
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,35 @@
+ja:
+  activerecord:
+    models:
+      user: "ユーザー"
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+        current_password: "現在のパスワード"
+        remember_me: "ログイン状態を保持する"
+
+  devise:
+    failure:
+      already_authenticated: "すでにログインしています。"
+      invalid: "メールアドレスまたはパスワードが正しくありません。"
+      not_found_in_database: "メールアドレスまたはパスワードが正しくありません。"
+      unauthenticated: "ログインしてください。"
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+    registrations:
+      signed_up: "アカウント登録が完了しました。"
+      updated: "ユーザー情報を更新しました。"
+      destroyed: "アカウントを削除しました。"
+    passwords:
+      send_instructions: "パスワード再設定メールを送信しました。"
+      updated: "パスワードを変更しました。"
+      updated_not_active: "パスワードを変更しました。"
+
+  errors:
+    messages:
+      not_saved:
+        one: "1件のエラーにより保存できませんでした。"
+        other: "%{count}件のエラーにより保存できませんでした。"


### PR DESCRIPTION
## 概要

ログイン状態保持機能を調整し、トップページの表示を見直しました。
あわせて Devise 画面の日本語化も追加しました。

## 変更内容

- Devise の rememberable を利用したログイン状態保持を調整
- ログイン画面に「ログイン状態を保持する」チェックボックスを追加
- ログイン後・新規登録後・ログアウト後の遷移先をトップページに統一
- トップページでログイン状態に応じた表示に変更
- ログイン中はトップページにアカウント名を表示するように変更
- Devise のログイン、新規登録、パスワード再設定、ユーザー編集画面を日本語化
- 日本語 locale を追加

## 確認内容

- チェックありでログインすると、ブラウザを閉じてもログイン状態が保持されること
- チェックなしでログインすると、ブラウザを閉じた後は未ログイン状態になること
- ログイン中はトップページにメールアドレスが表示されること
- 未ログイン時はトップページに新規登録・ログイン導線が表示されること
- ログイン画面、新規登録画面、パスワード再設定画面、ユーザー編集画面が日本語で表示されること
- 