### PR TITLE
不足アイテム一覧ページを追加

### DIFF
--- a/app/controllers/deficit_items_controller.rb
+++ b/app/controllers/deficit_items_controller.rb
@@ -1,0 +1,34 @@
+class DeficitItemsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @selected_sort = params[:sort].to_s.strip
+    @sort_options = [
+      ["50音順", "kana"],
+      ["不足数順", "deficit_quantity"],
+      ["必要数順", "required_quantity"]
+    ]
+
+    @deficit_items = Item
+      .includes(:user_items, :item_tasks, :item_hideouts)
+      .select { |item| item.deficit_quantity_for(current_user).positive? }
+
+    @deficit_items = sort_items(@deficit_items)
+    @user_items_by_item_id = current_user.user_items.index_by(&:item_id)
+  end
+
+  private
+
+  def sort_items(items)
+    case @selected_sort
+    when "deficit_quantity"
+      items.sort_by { |item| [-item.deficit_quantity_for(current_user), item.name] }
+    when "required_quantity"
+      items.sort_by { |item| [-item.total_required_quantity, item.name] }
+    when "kana"
+      items.sort_by(&:name)
+    else
+      items.sort_by(&:name)
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,6 +28,15 @@ class Item < ApplicationRecord
     task_required_quantity + hideout_required_quantity
   end
 
+  def owned_quantity_for(user)
+    user_item = user_items.find { |record| record.user_id == user.id }
+    user_item&.quantity.to_i
+  end
+
+  def deficit_quantity_for(user)
+    [total_required_quantity - owned_quantity_for(user), 0].max
+  end
+
   def usage_labels
     labels = []
     labels << "タスク" if item_tasks.exists?

--- a/app/views/deficit_items/index.html.erb
+++ b/app/views/deficit_items/index.html.erb
@@ -1,0 +1,58 @@
+<div class="detail-card" style="max-width: 900px; margin: 0 auto;">
+  <h1 class="detail-title">不足アイテム一覧</h1>
+
+  <p style="margin-bottom: 24px; line-height: 1.8;">
+    必要数に対して所持数が足りていないアイテムを一覧で確認できます。
+  </p>
+
+  <div class="field" style="margin-bottom: 24px;">
+    <%= form_with url: deficit_items_path, method: :get, local: true do %>
+      <div style="margin-bottom: 8px;">
+        <%= label_tag :sort, "並び順" %>
+      </div>
+      <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
+        <%= select_tag :sort, options_for_select(@sort_options, @selected_sort) %>
+        <%= submit_tag "適用" %>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @deficit_items.any? %>
+    <table style="width: 100%; border-collapse: collapse; margin-top: 16px;">
+      <thead>
+        <tr>
+          <th style="text-align: left; padding: 14px 10px; border-bottom: 1px solid #ccc;">アイテム名</th>
+          <th style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #ccc;">必要数</th>
+          <th style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #ccc;">所持数</th>
+          <th style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #ccc;">不足数</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @deficit_items.each do |item| %>
+          <% user_item = @user_items_by_item_id[item.id] %>
+          <% owned_quantity = user_item&.quantity.to_i %>
+          <tr>
+            <td style="padding: 14px 10px; border-bottom: 1px solid #eee; line-height: 1.6;">
+              <%= link_to item.name, item_path(item) %>
+            </td>
+            <td style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #eee;">
+              <%= item.total_required_quantity %>
+            </td>
+            <td style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #eee;">
+              <%= owned_quantity %>
+            </td>
+            <td style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #eee; font-weight: bold;">
+              <%= item.deficit_quantity_for(current_user) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p style="margin-top: 24px;">不足しているアイテムはありません。</p>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "アイテム一覧へ戻る", items_path %></p>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,6 +16,7 @@
 
     <div class="field" style="margin-top: 16px;">
       <p><%= link_to "アイテム一覧", items_path %></p>
+      <p><%= link_to "不足アイテム一覧", deficit_items_path %></p>
       <p><%= link_to "タスク一覧", tasks_path %></p>
       <p><%= link_to "ユーザー情報編集", edit_user_registration_path %></p>
       <p><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root "home#index"
   resources :items, only: %i[index show]
   resources :tasks, only: %i[index show]
+  resources :deficit_items, only: %i[index]
   patch "user_items", to: "user_items#update", as: :user_item
   patch "user_tasks", to: "user_tasks#update", as: :user_task
 


### PR DESCRIPTION
## 概要
不足しているアイテムだけを確認できる一覧ページを追加しました。

## 変更内容
- 不足アイテム一覧ページを追加
- 不足アイテム一覧へのルートを追加
- トップページに不足アイテム一覧へのリンクを追加
- Itemモデルに所持数・不足数を計算するメソッドを追加
- 不足アイテム一覧にソート機能を追加
  - 50音順
  - 不足数順
  - 必要数順

## 確認項目
- ログイン時のみ不足アイテム一覧ページにアクセスできる
- 不足しているアイテムのみ表示される
- 必要数、所持数、不足数が表示される
- ソート機能が動作する
- トップページから不足アイテム一覧へ遷移できる