### PR TITLE
アイテム一覧にページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.2.2"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.5"
 gem "devise"
+gem "kaminari"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,18 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     launchy (3.1.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -275,6 +287,7 @@ DEPENDENCIES
   debug
   devise
   importmap-rails
+  kaminari
   letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  PER_PAGE = 20
+
   def index
     @q = params[:q].to_s.strip
     @selected_level_range = params[:level_range].to_s.strip
@@ -11,7 +13,7 @@ class ItemsController < ApplicationController
       ["ハイドアウト必要数順", "hideout_required_quantity"]
     ]
 
-    @items = Item
+    items = Item
       .search_by_name(@q)
       .includes(item_tasks: :task, item_hideouts: :hideout)
       .order(:name)
@@ -19,10 +21,12 @@ class ItemsController < ApplicationController
 
     if @selected_level_range.present?
       level = @selected_level_range.to_i
-      @items = @items.select { |item| item.total_required_quantity_up_to_level(level).positive? }
+      items = items.select { |item| item.total_required_quantity_up_to_level(level).positive? }
     end
 
-    @items = sort_items(@items)
+    items = sort_items(items)
+
+    @items = Kaminari.paginate_array(items).page(params[:page]).per(PER_PAGE)
 
     if user_signed_in?
       @user_items_by_item_id = current_user.user_items.index_by(&:item_id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -93,6 +93,10 @@
         <% end %>
       </tbody>
     </table>
+
+    <div style="margin-top: 24px; text-align: center;">
+      <%= paginate @items %>
+    </div>
   <% else %>
     <p>該当するアイテムがありません。</p>
   <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -35,6 +35,14 @@ ja:
       reset_password_instructions:
         subject: "パスワード再設定のご案内"
 
+  views:
+    pagination:
+      first: "最初"
+      last: "最後"
+      previous: "前へ"
+      next: "次へ"
+      truncate: "..."
+
   errors:
     messages:
       not_saved:


### PR DESCRIPTION
## 概要
アイテム一覧画面にページネーションを追加しました。

## 変更内容
- kaminari を導入
- items#index にページネーションを追加
- 1ページあたり20件表示に設定
- アイテム一覧画面にページリンクを追加
- ページネーション文言を日本語化

## 確認項目
- アイテム一覧が複数ページに分かれて表示される
- 1ページあたり20件表示される
- 次ページ、最終ページなどのリンクが動作する
- ページネーション文言が日本語で表示される
- 検索・必要レベル帯・並び順と併用しても表示できる

Closes #68