### PR TITLE
管理者用のアイテム編集画面を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -137,10 +137,13 @@ a {
 }
 
 .simple-button {
+  display: inline-block;
   padding: 4px 10px;
   border: 1px solid #999;
   background-color: #efefef;
   cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .login-guide {
@@ -168,12 +171,126 @@ a {
 
 .detail-box {
   width: 100%;
-  height: 120px;
+  min-height: 120px;
   background-color: #e5e5e5;
   margin-bottom: 16px;
+  padding: 12px;
+}
+
+.detail-description-box {
+  height: auto;
+  line-height: 1.7;
 }
 
 .back-link {
   display: inline-block;
   margin-top: 8px;
+}
+
+/* admin */
+
+.admin-card {
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  border: 1px solid #cfcfcf;
+  background-color: #fff;
+  padding: 24px;
+}
+
+.admin-form-card {
+  max-width: 700px;
+  width: 100%;
+  margin: 0 auto;
+  border: 1px solid #cfcfcf;
+  background-color: #fff;
+  padding: 24px;
+}
+
+.admin-description {
+  margin-bottom: 24px;
+  line-height: 1.8;
+}
+
+.admin-search-area {
+  margin-bottom: 24px;
+}
+
+.admin-search-form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.admin-search-form input[type="text"] {
+  width: 240px;
+  padding: 4px 8px;
+}
+
+.admin-items-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+}
+
+.admin-items-table th,
+.admin-items-table td {
+  padding: 14px 10px;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}
+
+.admin-items-table th {
+  border-bottom: 1px solid #ccc;
+  background-color: #f8f8f8;
+}
+
+.admin-item-name {
+  width: 42%;
+  line-height: 1.6;
+  font-weight: bold;
+}
+
+.admin-item-description {
+  width: 43%;
+  line-height: 1.6;
+}
+
+.admin-action-column {
+  width: 100px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.admin-edit-button {
+  display: inline-block;
+  min-width: 56px;
+  padding: 6px 12px;
+  border: 1px solid #999;
+  background-color: #efefef;
+  text-decoration: none;
+  color: #000;
+  white-space: nowrap;
+}
+
+.admin-form-field {
+  margin-bottom: 16px;
+}
+
+.admin-text-field {
+  width: 100%;
+  max-width: 480px;
+  padding: 6px 8px;
+}
+
+.admin-text-area {
+  width: 100%;
+  padding: 8px;
+  line-height: 1.6;
+}
+
+.pagination-area {
+  margin-top: 24px;
+  text-align: center;
 }

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,4 +1,12 @@
 class Admin::BaseController < ApplicationController
   before_action :authenticate_user!
   before_action :require_admin!
+
+  private
+
+  def require_admin!
+    return if current_user&.admin?
+
+    redirect_to root_path, alert: "管理者権限が必要です。"
+  end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,32 @@
+class Admin::ItemsController < Admin::BaseController
+  def index
+    @q = params[:q].to_s.strip
+
+    @items = Item
+      .search_by_name(@q)
+      .order(:name)
+      .page(params[:page])
+      .per(20)
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+
+    if @item.update(item_params)
+      redirect_to admin_items_path, notice: "アイテム情報を更新しました。"
+    else
+      flash.now[:alert] = "アイテム情報の更新に失敗しました。"
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description)
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -4,9 +4,11 @@
   <p class="detail-label">管理者専用ページです。</p>
 
   <div class="detail-box">
-    <p>今後ここに管理者向け機能を追加していきます。</p>
-    <p>例: アイテム編集、タスク編集、データ追加</p>
+    <p>管理者向け機能をここから利用できます。</p>
   </div>
 
-  <%= link_to "アイテム一覧に戻る", items_path, class: "back-link" %>
+  <div class="field" style="margin-top: 16px;">
+    <p><%= link_to "アイテム編集", admin_items_path %></p>
+    <p><%= link_to "アイテム一覧に戻る", items_path %></p>
+  </div>
 </div>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,0 +1,39 @@
+<div class="admin-form-card">
+  <h1 class="detail-title">アイテム編集</h1>
+
+  <p class="admin-description">
+    アイテム名と詳細説明を編集できます。
+  </p>
+
+  <%= form_with model: [:admin, @item], local: true do |f| %>
+    <% if @item.errors.any? %>
+      <div class="flash-message alert">
+        <p><%= @item.errors.count %>件のエラーがあります。</p>
+        <ul>
+          <% @item.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="field admin-form-field">
+      <%= f.label :name, "アイテム名" %><br>
+      <%= f.text_field :name, class: "admin-text-field" %>
+    </div>
+
+    <div class="field admin-form-field">
+      <%= f.label :description, "詳細説明" %><br>
+      <%= f.text_area :description, rows: 8, class: "admin-text-area", placeholder: "アイテムの説明や補足情報を入力してください" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "更新する", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "管理者用アイテム一覧へ戻る", admin_items_path %></p>
+    <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
+  </div>
+</div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,64 @@
+<div class="admin-card">
+  <h1 class="detail-title">管理者用アイテム一覧</h1>
+
+  <p class="admin-description">
+    登録されているアイテム情報を編集できます。
+  </p>
+
+  <div class="admin-search-area">
+    <%= form_with url: admin_items_path, method: :get, local: true do %>
+      <div class="field">
+        <%= label_tag :q, "アイテム名で検索" %>
+      </div>
+
+      <div class="admin-search-form">
+        <%= text_field_tag :q, @q, placeholder: "アイテム名" %>
+        <%= submit_tag "検索", class: "simple-button" %>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @items.any? %>
+    <table class="admin-items-table">
+      <thead>
+        <tr>
+          <th>アイテム名</th>
+          <th>詳細</th>
+          <th class="admin-action-column">操作</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @items.each do |item| %>
+          <tr>
+            <td class="admin-item-name">
+              <%= item.name %>
+            </td>
+
+            <td class="admin-item-description">
+              <% if item.description.present? %>
+                <%= truncate(item.description, length: 80) %>
+              <% else %>
+                <span class="login-guide">未登録</span>
+              <% end %>
+            </td>
+
+            <td class="admin-action-column">
+              <%= link_to "編集", edit_admin_item_path(item), class: "admin-edit-button" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <div class="pagination-area">
+      <%= paginate @items %>
+    </div>
+  <% else %>
+    <p style="margin-top: 24px;">該当するアイテムがありません。</p>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
+  </div>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,15 @@
 <div class="detail-card">
   <h1 class="detail-title"><%= @item.name %></h1>
 
+  <p class="detail-label">詳細説明</p>
+  <div class="detail-box detail-description-box">
+    <% if @item.description.present? %>
+      <p><%= simple_format(@item.description) %></p>
+    <% else %>
+      <p>説明はまだ登録されていません。</p>
+    <% end %>
+  </div>
+
   <p class="detail-label">必要数合計: <%= @item.total_required_quantity %></p>
   <p class="detail-label">タスク必要数: <%= @item.task_required_quantity %></p>
   <p class="detail-label">ハイドアウト必要数: <%= @item.hideout_required_quantity %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root "dashboard#index"
     get "dashboard", to: "dashboard#index"
+    resources :items, only: %i[index edit update]
   end
 
   if Rails.env.development?

--- a/db/migrate/20260513193642_add_description_to_items.rb
+++ b/db/migrate/20260513193642_add_description_to_items.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_11_172651) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_13_193642) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,6 +44,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_11_172651) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description"
   end
 
   create_table "tasks", force: :cascade do |t|


### PR DESCRIPTION
## 概要
管理者用のアイテム編集画面を追加しました。

## 変更内容
- 管理者用アイテム一覧画面を追加
- 管理者用アイテム編集画面を追加
- アイテム名と詳細説明を編集できるように変更
- items に description カラムを追加
- アイテム詳細画面に詳細説明を表示
- 管理者用一覧画面の見切れを調整
- 管理者以外は管理画面にアクセスできないように制御

## 確認項目
- 管理者で `/admin/items` にアクセスできる
- 管理者用アイテム一覧が表示される
- アイテム名で検索できる
- 編集画面に遷移できる
- アイテム名と詳細説明を更新できる
- アイテム詳細画面に詳細説明が表示される
- 一覧の編集ボタンが見切れない
- 管理者以外は管理画面にアクセスできない

Closes #63