### PR TITLE
使い方説明ページを追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -294,3 +294,40 @@ a {
   margin-top: 24px;
   text-align: center;
 }
+
+/* guide */
+
+.guide-card {
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
+  border: 1px solid #cfcfcf;
+  background-color: #fff;
+  padding: 28px;
+}
+
+.guide-lead {
+  margin-bottom: 24px;
+  line-height: 1.8;
+}
+
+.guide-section {
+  margin-bottom: 24px;
+  padding: 16px;
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+}
+
+.guide-section h2 {
+  margin: 0 0 12px;
+  font-size: 20px;
+}
+
+.guide-section p {
+  margin: 0;
+  line-height: 1.8;
+}
+
+.guide-links {
+  margin-top: 28px;
+}

--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -1,0 +1,3 @@
+class GuidesController < ApplicationController
+  def show; end
+end

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -1,0 +1,70 @@
+<div class="guide-card">
+  <h1 class="detail-title">使い方</h1>
+
+  <p class="guide-lead">
+    EFT Item Manager は、Escape from Tarkov で必要になるアイテムを、
+    タスク・ハイドアウト・所持数とあわせて管理するためのアプリです。
+  </p>
+
+  <section class="guide-section">
+    <h2>1. アイテム一覧を確認する</h2>
+    <p>
+      「アイテム一覧」では、タスクやハイドアウトで必要になるアイテムを一覧で確認できます。
+      アイテム名で検索したり、必要レベル帯や並び順を変更して、必要なアイテムを探しやすくできます。
+    </p>
+  </section>
+
+  <section class="guide-section">
+    <h2>2. 所持数を登録する</h2>
+    <p>
+      ログインすると、アイテム一覧から現在の所持数を登録できます。
+      所持数を登録することで、必要数に対して足りているかどうかを確認できます。
+    </p>
+  </section>
+
+  <section class="guide-section">
+    <h2>3. 不足アイテム一覧を見る</h2>
+    <p>
+      「不足アイテム一覧」では、必要数に対して所持数が足りていないアイテムだけを確認できます。
+      何を優先して集めるべきかを判断しやすくなります。
+    </p>
+  </section>
+
+  <section class="guide-section">
+    <h2>4. タスク一覧を確認する</h2>
+    <p>
+      「タスク一覧」では、タスクの内容や必要レベルを確認できます。
+      タスクの進行状況を管理することで、進行に合わせて必要なアイテムを整理しやすくなります。
+    </p>
+  </section>
+
+  <section class="guide-section">
+    <h2>5. アイテム詳細を見る</h2>
+    <p>
+      アイテム名をクリックすると、アイテム詳細画面へ移動できます。
+      そのアイテムがどのタスクやハイドアウトで使われるかを確認できます。
+    </p>
+  </section>
+
+  <section class="guide-section">
+    <h2>6. 管理者機能について</h2>
+    <p>
+      管理者ユーザーは、管理画面からアイテム情報を編集できます。
+      通常ユーザーには管理画面へのリンクは表示されません。
+    </p>
+  </section>
+
+  <div class="guide-links">
+    <p><%= link_to "アイテム一覧を見る", items_path %></p>
+
+    <% if user_signed_in? %>
+      <p><%= link_to "不足アイテム一覧を見る", deficit_items_path %></p>
+      <p><%= link_to "タスク一覧を見る", tasks_path %></p>
+    <% else %>
+      <p><%= link_to "新規登録する", new_user_registration_path %></p>
+      <p><%= link_to "ログインする", new_user_session_path %></p>
+    <% end %>
+
+    <p><%= link_to "トップページへ戻る", root_path %></p>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,6 +15,7 @@
     </p>
 
     <div class="field" style="margin-top: 16px;">
+      <p><%= link_to "使い方", guide_path %></p>
       <p><%= link_to "アイテム一覧", items_path %></p>
       <p><%= link_to "不足アイテム一覧", deficit_items_path %></p>
       <p><%= link_to "タスク一覧", tasks_path %></p>
@@ -32,6 +33,7 @@
     </p>
 
     <div class="field" style="margin-top: 16px;">
+      <p><%= link_to "使い方", guide_path %></p>
       <p><%= link_to "アイテム一覧", items_path %></p>
       <p><%= link_to "新規登録", new_user_registration_path %></p>
       <p><%= link_to "ログイン", new_user_session_path %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
         </div>
 
         <nav class="header-nav">
+          <%= link_to "使い方", guide_path, class: "header-button" %>
+
           <% if user_signed_in? %>
             <%= link_to "マイページ", items_path, class: "header-button" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "home#index"
+  get "guide", to: "guides#show", as: :guide
   resources :items, only: %i[index show]
   resources :tasks, only: %i[index show]
   resources :deficit_items, only: %i[index]


### PR DESCRIPTION
## 概要
アプリの使い方を説明するページを追加しました。

## 変更内容
- `/guide` に使い方説明ページを追加
- ヘッダーに「使い方」リンクを追加
- トップページに「使い方」リンクを追加
- アイテム一覧、所持数登録、不足アイテム一覧、タスク一覧、アイテム詳細の使い方を説明
- 管理者機能についての簡単な説明を追加
- 使い方ページ用のスタイルを追加

## 確認項目
- `/guide` にアクセスできる
- ヘッダーから使い方ページへ遷移できる
- トップページから使い方ページへ遷移できる
- ログイン前でも使い方ページを閲覧できる
- ログイン後でも使い方ページを閲覧できる
- 使い方ページの表示が崩れていない

Closes #74