### PR TITLE
利用規約とプライバシーポリシーページを追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -36,6 +36,8 @@ a {
 .header-nav {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .header-button {
@@ -46,6 +48,7 @@ a {
   text-decoration: none;
   font-size: 12px;
   color: #000;
+  white-space: nowrap;
 }
 
 .page-container {
@@ -330,4 +333,75 @@ a {
 
 .guide-links {
   margin-top: 28px;
+}
+
+/* static pages */
+
+.static-page-card {
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
+  border: 1px solid #cfcfcf;
+  background-color: #fff;
+  padding: 28px;
+}
+
+.static-page-lead {
+  margin-bottom: 24px;
+  line-height: 1.8;
+}
+
+.static-page-section {
+  margin-bottom: 24px;
+  padding: 16px;
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+}
+
+.static-page-section h2 {
+  margin: 0 0 12px;
+  font-size: 20px;
+}
+
+.static-page-section p {
+  margin: 0;
+  line-height: 1.8;
+}
+
+.static-page-section ul {
+  margin: 12px 0 0;
+  padding-left: 24px;
+  line-height: 1.8;
+}
+
+.static-page-date {
+  margin-top: 24px;
+  font-size: 13px;
+  color: #555;
+}
+
+.static-page-links {
+  margin-top: 28px;
+}
+
+/* footer */
+
+.site-footer {
+  width: 960px;
+  margin: 0 auto 24px;
+  padding: 12px 24px;
+  text-align: center;
+  font-size: 13px;
+  color: #555;
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.footer-inner a {
+  text-decoration: underline;
 }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,5 @@
+class StaticPagesController < ApplicationController
+  def terms; end
+
+  def privacy; end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,5 +48,13 @@
 
       <%= yield %>
     </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <%= link_to "利用規約", terms_path %>
+        <span>|</span>
+        <%= link_to "プライバシーポリシー", privacy_path %>
+      </div>
+    </footer>
   </body>
 </html>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,72 @@
+<div class="static-page-card">
+  <h1 class="detail-title">プライバシーポリシー</h1>
+
+  <p class="static-page-lead">
+    EFT Item Manager は、ユーザーの個人情報の重要性を認識し、
+    適切な管理と保護に努めます。
+  </p>
+
+  <section class="static-page-section">
+    <h2>1. 取得する情報</h2>
+    <p>
+      本アプリでは、ユーザー登録やログイン機能の提供のため、メールアドレスなどの情報を取得する場合があります。
+      また、アプリ内で登録されたアイテム所持数やタスク進行状況を保存します。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>2. 利用目的</h2>
+    <p>取得した情報は、以下の目的で利用します。</p>
+    <ul>
+      <li>ユーザー認証のため</li>
+      <li>アイテム所持数やタスク進行状況を管理するため</li>
+      <li>本アプリの機能改善や不具合対応のため</li>
+      <li>必要に応じた連絡や案内のため</li>
+    </ul>
+  </section>
+
+  <section class="static-page-section">
+    <h2>3. 第三者提供</h2>
+    <p>
+      管理者は、法令に基づく場合を除き、ユーザー本人の同意なく個人情報を第三者に提供しません。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>4. 情報の管理</h2>
+    <p>
+      管理者は、取得した情報の漏えい、紛失、改ざんなどを防止するため、
+      適切な安全管理に努めます。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>5. Cookie等の利用</h2>
+    <p>
+      本アプリでは、ログイン状態の管理などに Cookie を使用する場合があります。
+      Cookie はブラウザの設定により無効にできますが、その場合一部機能が利用できないことがあります。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>6. プライバシーポリシーの変更</h2>
+    <p>
+      管理者は、必要に応じて本ポリシーを変更できるものとします。
+      変更後の内容は、本アプリ上に表示した時点で効力を生じるものとします。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>7. お問い合わせ</h2>
+    <p>
+      個人情報の取り扱いに関するお問い合わせは、管理者が定める方法により行うものとします。
+    </p>
+  </section>
+
+  <p class="static-page-date">制定日：2026年5月15日</p>
+
+  <div class="static-page-links">
+    <p><%= link_to "利用規約", terms_path %></p>
+    <p><%= link_to "トップページへ戻る", root_path %></p>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,73 @@
+<div class="static-page-card">
+  <h1 class="detail-title">利用規約</h1>
+
+  <p class="static-page-lead">
+    この利用規約は、EFT Item Manager の利用条件を定めるものです。
+    本アプリを利用する場合、本規約に同意したものとみなします。
+  </p>
+
+  <section class="static-page-section">
+    <h2>第1条（本アプリについて）</h2>
+    <p>
+      本アプリは、Escape from Tarkov において必要となるアイテムを、
+      タスク・ハイドアウト・所持数とあわせて管理するためのサービスです。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>第2条（利用登録）</h2>
+    <p>
+      ユーザーは、本アプリの利用にあたり、正確な情報を登録するものとします。
+      登録情報に誤りがある場合、本アプリの一部機能を正しく利用できない場合があります。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>第3条（禁止事項）</h2>
+    <p>ユーザーは、本アプリの利用にあたり、以下の行為を行ってはなりません。</p>
+    <ul>
+      <li>法令または公序良俗に反する行為</li>
+      <li>他のユーザーまたは第三者に不利益や損害を与える行為</li>
+      <li>本アプリの運営を妨害する行為</li>
+      <li>不正アクセス、またはこれを試みる行為</li>
+      <li>その他、管理者が不適切と判断する行為</li>
+    </ul>
+  </section>
+
+  <section class="static-page-section">
+    <h2>第4条（免責事項）</h2>
+    <p>
+      本アプリで提供する情報について、正確性や完全性を保証するものではありません。
+      本アプリの利用により生じた損害について、管理者は責任を負わないものとします。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>第5条（サービス内容の変更・停止）</h2>
+    <p>
+      管理者は、必要に応じて、本アプリの内容を変更、追加、停止または終了できるものとします。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>第6条（規約の変更）</h2>
+    <p>
+      管理者は、必要に応じて本規約を変更できるものとします。
+      変更後の規約は、本アプリ上に表示した時点で効力を生じるものとします。
+    </p>
+  </section>
+
+  <section class="static-page-section">
+    <h2>第7条（お問い合わせ）</h2>
+    <p>
+      本規約に関するお問い合わせは、管理者が定める方法により行うものとします。
+    </p>
+  </section>
+
+  <p class="static-page-date">制定日：2026年5月15日</p>
+
+  <div class="static-page-links">
+    <p><%= link_to "プライバシーポリシー", privacy_path %></p>
+    <p><%= link_to "トップページへ戻る", root_path %></p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
 
   root "home#index"
   get "guide", to: "guides#show", as: :guide
+  get "terms", to: "static_pages#terms", as: :terms
+  get "privacy", to: "static_pages#privacy", as: :privacy
+
   resources :items, only: %i[index show]
   resources :tasks, only: %i[index show]
   resources :deficit_items, only: %i[index]


### PR DESCRIPTION
## 概要
利用規約ページとプライバシーポリシーページを追加しました。

## 変更内容
- `/terms` に利用規約ページを追加
- `/privacy` にプライバシーポリシーページを追加
- 静的ページ用の controller を追加
- フッターに利用規約・プライバシーポリシーへのリンクを追加
- 静的ページ用のスタイルを追加
- ヘッダーのリンクが折り返しても崩れないように調整

## 確認項目
- `/terms` にアクセスできる
- `/privacy` にアクセスできる
- 各ページの表示が崩れていない
- フッターから利用規約ページへ遷移できる
- フッターからプライバシーポリシーページへ遷移できる
- ヘッダーには使い方リンクのみ表示されている
- `bin/rails zeitwerk:check` が通る

Closes #75