### PR TITLE
アイテム検索にオートコンプリートを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,6 +12,7 @@ class ItemsController < ApplicationController
       ["タスク必要数順", "task_required_quantity"],
       ["ハイドアウト必要数順", "hideout_required_quantity"]
     ]
+    @item_names = Item.order(:name).pluck(:name)
 
     items = Item
       .search_by_name(@q)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -11,7 +11,13 @@
 
   <%= form_with url: items_path, method: :get, local: true, class: "items-search-form" do %>
     <%= label_tag :q, "検索" %>
-    <%= text_field_tag :q, @q, id: "item-search", placeholder: "アイテム名" %>
+    <%= text_field_tag :q, @q, id: "item-search", placeholder: "アイテム名", list: "item-name-list" %>
+
+    <datalist id="item-name-list">
+      <% @item_names.each do |item_name| %>
+        <option value="<%= item_name %>"></option>
+      <% end %>
+    </datalist>
 
     <%= label_tag :level_range, "必要レベル帯" %>
     <%= select_tag :level_range,


### PR DESCRIPTION
## 概要
アイテム一覧の検索フォームにオートコンプリート機能を追加しました。

## 変更内容
- アイテム検索欄に datalist を追加
- 入力中にアイテム名の候補を表示できるように変更
- ItemsController でアイテム名一覧を取得するように変更
- 既存の検索・必要レベル帯・並び順・ページネーションと併用できるように対応

## 確認項目
- アイテム一覧の検索欄に入力すると候補が表示される
- 候補を選択して検索できる
- 手入力でも検索できる
- 必要レベル帯との併用ができる
- 並び順との併用ができる
- ページネーションが今まで通り動作する
- `bin/rails zeitwerk:check` が通る

Closes #76