### PR TITLE
管理画面のUI改善とマスターデータ追加機能を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -3,55 +3,97 @@
 }
 
 body {
+  width: 100%;
   margin: 0;
-  background-color: #f3f3f3;
   color: #222;
-  font-family: Arial, sans-serif;
+  background-color: #eeeeee;
+  font-family: Arial, "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
+  line-height: 1.6;
 }
 
 a {
-  color: inherit;
+  color: #111;
 }
 
+a:hover {
+  opacity: 0.75;
+}
+
+p {
+  margin-top: 0;
+}
+
+table {
+  border-collapse: collapse;
+}
+
+input,
+textarea,
+select,
+button {
+  font: inherit;
+}
+
+/* layout */
+
 .site-header {
-  background-color: #bdbdbd;
-  border-bottom: 1px solid #999;
+  width: 100%;
+  background-color: #bfbfbf;
+  border-bottom: 1px solid #9f9f9f;
 }
 
 .header-inner {
-  width: 960px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 10px 12px;
+  padding: 12px 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+}
+
+.header-logo {
+  font-weight: bold;
+  font-size: 18px;
+  white-space: nowrap;
 }
 
 .header-logo a {
-  text-decoration: none;
-  font-weight: bold;
   color: #000;
+  text-decoration: none;
 }
 
 .header-nav {
   display: flex;
   gap: 8px;
+  align-items: center;
   flex-wrap: wrap;
   justify-content: flex-end;
-  align-items: center;
 }
 
 .header-button {
   display: inline-block;
-  padding: 4px 10px;
+  padding: 6px 12px;
   border: 1px solid #999;
   background-color: #efefef;
-  text-decoration: none;
-  font-size: 12px;
   color: #000;
-  white-space: nowrap;
+  text-decoration: none;
   cursor: pointer;
+  white-space: nowrap;
 }
+
+.header-button:hover {
+  background-color: #e2e2e2;
+  opacity: 1;
+}
+
+.page-container {
+  width: 960px;
+  max-width: calc(100% - 32px);
+  margin: 24px auto;
+}
+
+/* header dropdown */
 
 .header-dropdown {
   position: relative;
@@ -59,149 +101,74 @@ a {
 }
 
 .header-dropdown-button {
-  font-family: inherit;
+  cursor: pointer;
 }
 
 .header-dropdown-menu {
   display: none;
   position: absolute;
-  right: 0;
-  top: 100%;
-  min-width: 160px;
-  background-color: #fff;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  min-width: 180px;
   border: 1px solid #999;
-  z-index: 10;
+  background-color: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
-.header-dropdown:hover .header-dropdown-menu {
+.header-dropdown:hover .header-dropdown-menu,
+.header-dropdown:focus-within .header-dropdown-menu {
   display: block;
 }
 
 .header-dropdown-menu a {
   display: block;
-  padding: 8px 12px;
-  text-decoration: none;
-  font-size: 13px;
+  padding: 8px 10px;
   color: #000;
+  text-decoration: none;
   white-space: nowrap;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.header-dropdown-menu a:last-child {
+  border-bottom: none;
 }
 
 .header-dropdown-menu a:hover {
-  background-color: #efefef;
+  background-color: #f0f0f0;
+  opacity: 1;
 }
 
-.page-container {
-  width: 960px;
-  margin: 24px auto;
-  padding: 24px;
-  background-color: #fff;
-  min-height: 600px;
-  border: 1px solid #ccc;
-}
+/* flash */
 
 .flash-message {
-  margin: 0 0 16px;
-  padding: 10px 12px;
-  border: 1px solid #ccc;
-  background-color: #f8f8f8;
+  max-width: 960px;
+  margin: 0 auto 16px;
+  padding: 12px 16px;
+  border: 1px solid #cfcfcf;
+  background-color: #f7f7f7;
 }
 
 .flash-message.notice {
-  color: #1b5e20;
+  color: #1f6b2a;
+  border-color: #cbdccf;
+  background-color: #f3faf4;
 }
 
 .flash-message.alert {
-  color: #b71c1c;
+  color: #8a1f1f;
+  border-color: #e1c5c5;
+  background-color: #fff5f5;
 }
 
-.page-title {
-  margin: 0 0 24px;
-  font-size: 32px;
-}
+/* common cards */
 
-.items-search-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-}
-
-.items-search-form {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.items-search-form input[type="text"] {
-  width: 180px;
-  padding: 4px 8px;
-}
-
-.items-table-wrapper {
-  background-color: #efefef;
-  padding: 16px;
-  min-height: 360px;
-}
-
-.items-table {
-  width: 100%;
-  border-collapse: collapse;
-  background-color: #fff;
-}
-
-.items-table th,
-.items-table td {
-  padding: 10px 12px;
-  border: 1px solid #cfcfcf;
-  text-align: left;
-  vertical-align: middle;
-}
-
-.items-table th {
-  background-color: #e2e2e2;
-  font-size: 14px;
-}
-
-.item-name-link {
-  font-weight: bold;
-  text-decoration: underline;
-}
-
-.quantity-form {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.quantity-form input[type="number"] {
-  width: 72px;
-  padding: 4px 6px;
-}
-
-.simple-button {
-  display: inline-block;
-  padding: 4px 10px;
-  border: 1px solid #999;
-  background-color: #efefef;
-  cursor: pointer;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.login-guide {
-  font-size: 13px;
-  color: #555;
-}
-
-.detail-card {
-  width: 540px;
-  border: 1px solid #cfcfcf;
-  background-color: #fff;
-  padding: 24px;
-}
-
-.home-card {
-  max-width: 760px;
+.home-card,
+.detail-card,
+.admin-card,
+.admin-form-card,
+.guide-card,
+.static-page-card {
   width: 100%;
   margin: 0 auto;
   border: 1px solid #cfcfcf;
@@ -209,94 +176,176 @@ a {
   padding: 28px;
 }
 
+.home-card {
+  max-width: 620px;
+}
+
+.detail-card {
+  max-width: 900px;
+}
+
+.admin-card {
+  max-width: 980px;
+}
+
+.admin-form-card {
+  max-width: 760px;
+}
+
+.admin-task-edit-card,
+.admin-item-edit-card {
+  max-width: 980px;
+}
+
+.guide-card,
+.static-page-card {
+  max-width: 760px;
+}
+
 .detail-title {
-  margin: 0 0 24px;
-  text-align: center;
-  font-size: 28px;
+  margin-top: 0;
+  margin-bottom: 18px;
+  font-size: 30px;
+  line-height: 1.3;
 }
 
 .detail-label {
-  margin: 0 0 8px;
-  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 8px;
 }
 
 .detail-box {
-  width: 100%;
-  min-height: 120px;
-  background-color: #e5e5e5;
+  margin-top: 16px;
   margin-bottom: 16px;
-  padding: 12px;
+  padding: 16px;
+  border: 1px solid #d8d8d8;
+  background-color: #f7f7f7;
 }
 
-.detail-description-box {
-  height: auto;
-  line-height: 1.7;
+.detail-box p:last-child {
+  margin-bottom: 0;
 }
 
-.back-link {
+.field {
+  margin-bottom: 14px;
+}
+
+.actions {
+  margin-top: 20px;
+}
+
+.login-guide,
+.text-muted {
+  color: #777;
+}
+
+.simple-button,
+input[type="submit"].simple-button {
   display: inline-block;
-  margin-top: 8px;
+  padding: 6px 12px;
+  border: 1px solid #999;
+  background-color: #efefef;
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.simple-button:hover,
+input[type="submit"].simple-button:hover {
+  background-color: #e2e2e2;
+  opacity: 1;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+textarea,
+select {
+  border: 1px solid #999;
+  background-color: #fff;
+  padding: 6px 8px;
+}
+
+/* home */
+
+.home-title {
+  text-align: center;
+  font-size: 30px;
+  margin-top: 0;
+  margin-bottom: 24px;
 }
 
 .home-feature-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr;
   gap: 12px;
-  margin-top: 24px;
+  margin-top: 20px;
 }
 
 .home-feature-card {
   display: block;
   padding: 16px;
-  border: 1px solid #ccc;
-  background-color: #f5f5f5;
+  border: 1px solid #d8d8d8;
+  background-color: #fafafa;
+  color: #111;
   text-decoration: none;
-  color: #222;
 }
 
 .home-feature-card:hover {
-  background-color: #efefef;
+  background-color: #f0f0f0;
+  opacity: 1;
 }
 
 .home-feature-card h2 {
-  margin: 0 0 8px;
+  margin-top: 0;
+  margin-bottom: 8px;
   font-size: 18px;
 }
 
-.home-feature-card p {
-  margin: 0;
-  line-height: 1.6;
+.home-feature-card p:last-child {
+  margin-bottom: 0;
 }
 
-/* admin */
-
-.admin-card {
-  max-width: 900px;
-  width: 100%;
-  margin: 0 auto;
-  border: 1px solid #cfcfcf;
-  background-color: #fff;
-  padding: 24px;
-}
-
-.admin-form-card {
-  max-width: 700px;
-  width: 100%;
-  margin: 0 auto;
-  border: 1px solid #cfcfcf;
-  background-color: #fff;
-  padding: 24px;
-}
-
-.admin-description {
-  margin-bottom: 24px;
+.guest-guide-box,
+.guest-login-box,
+.guest-feature-box,
+.user-guide-box {
+  margin-top: 16px;
+  padding: 12px;
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
   line-height: 1.8;
 }
 
+.guest-guide-box ul,
+.guest-feature-box ul,
+.user-guide-box ul {
+  margin: 8px 0 12px;
+  padding-left: 24px;
+}
+
+/* list / search */
+
+.page-header {
+  max-width: 900px;
+  margin: 0 auto 16px;
+}
+
+.search-area,
+.search-form,
 .admin-search-area {
   margin-bottom: 24px;
 }
 
+.search-area,
+.admin-search-area {
+  padding: 16px;
+  border: 1px solid #d8d8d8;
+  background-color: #f7f7f7;
+}
+
+.search-form form,
 .admin-search-form {
   display: flex;
   gap: 8px;
@@ -304,17 +353,30 @@ a {
   flex-wrap: wrap;
 }
 
+.search-form input[type="text"],
 .admin-search-form input[type="text"] {
   width: 240px;
-  padding: 4px 8px;
+  padding: 6px 8px;
 }
 
+/* tables */
+
+.items-table,
+.tasks-table,
+.deficit-items-table,
 .admin-items-table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 16px;
+  background-color: #fff;
 }
 
+.items-table th,
+.items-table td,
+.tasks-table th,
+.tasks-table td,
+.deficit-items-table th,
+.deficit-items-table td,
 .admin-items-table th,
 .admin-items-table td {
   padding: 14px 10px;
@@ -322,19 +384,23 @@ a {
   vertical-align: top;
 }
 
+.items-table th,
+.tasks-table th,
+.deficit-items-table th,
 .admin-items-table th {
   border-bottom: 1px solid #ccc;
   background-color: #f8f8f8;
+  text-align: left;
 }
 
+.item-name,
+.task-name,
 .admin-item-name {
-  width: 42%;
-  line-height: 1.6;
   font-weight: bold;
+  line-height: 1.6;
 }
 
 .admin-item-description {
-  width: 43%;
   line-height: 1.6;
 }
 
@@ -355,6 +421,17 @@ a {
   white-space: nowrap;
 }
 
+.admin-edit-button:hover {
+  background-color: #e2e2e2;
+  opacity: 1;
+}
+
+/* forms */
+
+.quantity-field {
+  width: 80px;
+}
+
 .admin-form-field {
   margin-bottom: 16px;
 }
@@ -371,64 +448,241 @@ a {
   line-height: 1.6;
 }
 
-.pagination-area {
+.admin-number-field {
+  width: 120px;
+  padding: 6px;
+  border: 1px solid #999;
+}
+
+.admin-select-field {
+  width: 100%;
+  max-width: 220px;
+  padding: 6px;
+  border: 1px solid #999;
+  background-color: #fff;
+}
+
+.admin-required-quantity-field {
+  width: 90px;
+  padding: 6px;
+  border: 1px solid #999;
+}
+
+/* admin dashboard */
+
+.admin-description {
+  margin-bottom: 24px;
+  line-height: 1.8;
+}
+
+.admin-menu-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
   margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.admin-menu-card {
+  border: 1px solid #cfcfcf;
+  background-color: #f9f9f9;
+  padding: 20px;
+}
+
+.admin-menu-title {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 20px;
+}
+
+.admin-menu-text {
+  margin-bottom: 16px;
+  line-height: 1.7;
+}
+
+.admin-menu-button {
+  display: inline-block;
+  border: 1px solid #333;
+  background-color: #fff;
+  color: #000;
+  padding: 8px 14px;
+  text-decoration: none;
+}
+
+.admin-menu-button:hover {
+  background-color: #eeeeee;
+  opacity: 1;
+}
+
+.admin-note-box {
+  margin-top: 16px;
+}
+
+/* admin filters */
+
+.admin-filter-grid {
+  display: grid;
+  grid-template-columns: 1fr 220px 220px auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.admin-filter-action {
+  margin-bottom: 14px;
+}
+
+/* admin edit sections */
+
+.admin-edit-section {
+  margin-top: 24px;
+  margin-bottom: 28px;
+}
+
+.admin-section-title {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 20px;
+}
+
+.admin-quantity-table {
+  margin-top: 12px;
+}
+
+.admin-add-item-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) 160px;
+  gap: 16px;
+  align-items: end;
+}
+
+.admin-add-item-select {
+  max-width: 100%;
+}
+
+.admin-delete-check-label {
+  white-space: nowrap;
+}
+
+/* status colors */
+
+.status-needed,
+.status-text-danger {
+  color: #b3261e;
+  font-weight: bold;
+}
+
+.status-enough,
+.status-text-success {
+  color: #1f6b2a;
+  font-weight: bold;
+}
+
+.status-button-success,
+.status-button-danger {
+  display: inline-block;
+  min-width: 82px;
+  padding: 6px 12px;
+  border: 1px solid transparent;
+  color: #fff;
   text-align: center;
+  cursor: pointer;
+}
+
+.status-button-success {
+  background-color: #2f7d32;
+  border-color: #256628;
+}
+
+.status-button-danger {
+  background-color: #b3261e;
+  border-color: #8f1d17;
+}
+
+.status-button-success:hover,
+.status-button-danger:hover {
+  opacity: 0.85;
+}
+
+.status-badge-success,
+.status-badge-danger {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 2px;
+  font-size: 13px;
+  font-weight: bold;
+}
+
+.status-badge-success {
+  color: #1f6b2a;
+  background-color: #edf8ef;
+  border: 1px solid #b8d8bd;
+}
+
+.status-badge-danger {
+  color: #8a1f1f;
+  background-color: #fff0f0;
+  border: 1px solid #e2b6b6;
+}
+
+/* item detail */
+
+.usage-labels {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.usage-label {
+  display: inline-block;
+  border: 1px solid #aaa;
+  background-color: #f7f7f7;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+
+.usage-section {
+  margin-top: 24px;
+}
+
+.usage-list {
+  margin-top: 8px;
+  padding-left: 20px;
+}
+
+.usage-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.usage-summary-card {
+  border: 1px solid #d8d8d8;
+  background-color: #f7f7f7;
+  padding: 14px;
+}
+
+.usage-summary-label {
+  color: #666;
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.usage-summary-value {
+  font-size: 24px;
+  font-weight: bold;
 }
 
 /* guide */
 
-.guide-card {
-  max-width: 760px;
-  width: 100%;
-  margin: 0 auto;
-  border: 1px solid #cfcfcf;
-  background-color: #fff;
-  padding: 28px;
-}
-
-.guide-lead {
-  margin-bottom: 24px;
-  line-height: 1.8;
-}
-
-.guide-section {
-  margin-bottom: 24px;
-  padding: 16px;
-  background-color: #f5f5f5;
-  border: 1px solid #ddd;
-}
-
-.guide-section h2 {
-  margin: 0 0 12px;
-  font-size: 20px;
-}
-
-.guide-section p {
-  margin: 0;
-  line-height: 1.8;
-}
-
-.guide-links {
-  margin-top: 28px;
-}
-
-/* static pages */
-
-.static-page-card {
-  max-width: 760px;
-  width: 100%;
-  margin: 0 auto;
-  border: 1px solid #cfcfcf;
-  background-color: #fff;
-  padding: 28px;
-}
-
+.guide-lead,
 .static-page-lead {
   margin-bottom: 24px;
   line-height: 1.8;
 }
 
+.guide-section,
 .static-page-section {
   margin-bottom: 24px;
   padding: 16px;
@@ -436,11 +690,13 @@ a {
   border: 1px solid #ddd;
 }
 
+.guide-section h2,
 .static-page-section h2 {
   margin: 0 0 12px;
   font-size: 20px;
 }
 
+.guide-section p,
 .static-page-section p {
   margin: 0;
   line-height: 1.8;
@@ -452,20 +708,55 @@ a {
   line-height: 1.8;
 }
 
+.guide-links,
+.static-page-links {
+  margin-top: 28px;
+}
+
 .static-page-date {
   margin-top: 24px;
   font-size: 13px;
   color: #555;
 }
 
-.static-page-links {
-  margin-top: 28px;
+/* pagination */
+
+.pagination-area {
+  margin-top: 24px;
+  text-align: center;
+}
+
+.pagination {
+  display: inline-flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.pagination span {
+  display: inline-block;
+}
+
+.pagination a,
+.pagination .current {
+  display: inline-block;
+  border: 1px solid #bbb;
+  background-color: #fff;
+  color: #000;
+  padding: 5px 9px;
+  text-decoration: none;
+}
+
+.pagination .current {
+  background-color: #333;
+  color: #fff;
 }
 
 /* footer */
 
 .site-footer {
   width: 960px;
+  max-width: calc(100% - 32px);
   margin: 0 auto 24px;
   padding: 12px 24px;
   text-align: center;
@@ -484,7 +775,7 @@ a {
   text-decoration: underline;
 }
 
-/* guest */
+/* utility */
 
 .current-user-label {
   max-width: 220px;
@@ -492,20 +783,168 @@ a {
   line-height: 1.5;
 }
 
-.guest-guide-box,
-.guest-login-box,
-.guest-feature-box,
-.user-guide-box {
+.mt-16 {
   margin-top: 16px;
-  padding: 12px;
-  background-color: #f5f5f5;
-  border: 1px solid #ddd;
-  line-height: 1.8;
 }
 
-.guest-guide-box ul,
-.guest-feature-box ul,
-.user-guide-box ul {
-  margin: 8px 0 12px;
-  padding-left: 24px;
+.mt-24 {
+  margin-top: 24px;
+}
+
+/* responsive */
+
+@media (max-width: 900px) {
+  .header-inner,
+  .page-container,
+  .site-footer {
+    max-width: calc(100% - 24px);
+  }
+
+  .home-card,
+  .detail-card,
+  .admin-card,
+  .admin-form-card,
+  .guide-card,
+  .static-page-card {
+    padding: 20px;
+  }
+
+  .usage-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-filter-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header-nav {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .header-dropdown {
+    width: 100%;
+  }
+
+  .header-dropdown-button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .header-dropdown-menu {
+    position: static;
+    width: 100%;
+    margin-top: 4px;
+    box-shadow: none;
+  }
+
+  .detail-title,
+  .home-title {
+    font-size: 24px;
+  }
+
+  .admin-menu-grid,
+  .admin-filter-grid,
+  .admin-add-item-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-select-field,
+  .admin-number-field,
+  .admin-add-item-select {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .items-table,
+  .tasks-table,
+  .deficit-items-table,
+  .admin-items-table {
+    font-size: 14px;
+  }
+
+  .items-table th,
+  .items-table td,
+  .tasks-table th,
+  .tasks-table td,
+  .deficit-items-table th,
+  .deficit-items-table td,
+  .admin-items-table th,
+  .admin-items-table td {
+    padding: 8px;
+  }
+
+  .admin-action-column {
+    width: auto;
+  }
+
+  .status-button-success,
+  .status-button-danger {
+    width: 100%;
+  }
+}
+
+@media (max-width: 560px) {
+  .header-inner,
+  .page-container,
+  .site-footer {
+    max-width: calc(100% - 16px);
+  }
+
+  .home-card,
+  .detail-card,
+  .admin-card,
+  .admin-form-card,
+  .guide-card,
+  .static-page-card {
+    padding: 16px;
+  }
+
+  .search-form form,
+  .admin-search-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-form input[type="text"],
+  .admin-search-form input[type="text"] {
+    width: 100%;
+  }
+
+  .header-button,
+  .simple-button,
+  .admin-edit-button,
+  .admin-menu-button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .items-table,
+  .tasks-table,
+  .deficit-items-table,
+  .admin-items-table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}
+
+/* admin task item search */
+
+.admin-add-item-name-field {
+  max-width: 100%;
+}
+
+/* admin create actions */
+
+.admin-page-actions {
+  margin-top: 16px;
+  margin-bottom: 24px;
 }

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -9,24 +9,69 @@ class Admin::ItemsController < Admin::BaseController
       .per(20)
   end
 
+  def new
+    @item = Item.new
+  end
+
+  def create
+    @item = Item.new(item_params)
+
+    if @item.save
+      redirect_to edit_admin_item_path(@item), notice: "アイテムを追加しました。必要数はタスク編集画面またはアイテム編集画面から設定してください。"
+    else
+      flash.now[:alert] = "アイテムの追加に失敗しました。入力内容を確認してください。"
+      render :new, status: :unprocessable_content
+    end
+  end
+
   def edit
     @item = Item.find(params[:id])
+    set_required_quantity_records
   end
 
   def update
     @item = Item.find(params[:id])
 
-    if @item.update(item_params)
-      redirect_to admin_items_path, notice: "アイテム情報を更新しました。"
-    else
-      flash.now[:alert] = "アイテム情報の更新に失敗しました。"
-      render :edit, status: :unprocessable_content
+    ActiveRecord::Base.transaction do
+      @item.update!(item_params)
+      update_required_quantities(@item.item_tasks, params[:item_task_required_quantities])
+      update_required_quantities(@item.item_hideouts, params[:item_hideout_required_quantities])
     end
+
+    redirect_to admin_items_path, notice: "アイテム情報を更新しました。"
+  rescue ActiveRecord::RecordInvalid
+    set_required_quantity_records
+    flash.now[:alert] = "アイテム情報の更新に失敗しました。入力内容を確認してください。"
+    render :edit, status: :unprocessable_content
   end
 
   private
 
   def item_params
     params.require(:item).permit(:name, :description)
+  end
+
+  def set_required_quantity_records
+    @item_tasks = @item
+      .item_tasks
+      .joins(:task)
+      .includes(:task)
+      .order("tasks.level ASC, tasks.trader ASC, tasks.name ASC")
+
+    @item_hideouts = @item
+      .item_hideouts
+      .joins(:hideout)
+      .includes(:hideout)
+      .order("hideouts.name ASC")
+  end
+
+  def update_required_quantities(records, quantity_params)
+    return if quantity_params.blank?
+
+    records.each do |record|
+      next unless quantity_params.key?(record.id.to_s)
+
+      record.update!(required_quantity: quantity_params[record.id.to_s])
+    end
   end
 end

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,0 +1,122 @@
+class Admin::TasksController < Admin::BaseController
+  def index
+    @q = params[:q].to_s.strip
+    @trader = params[:trader].to_s.strip
+
+    @tasks = Task.includes(:items)
+    @tasks = @tasks.where("name ILIKE ?", "%#{@q}%") if @q.present?
+    @tasks = @tasks.where(trader: @trader) if @trader.present?
+
+    @tasks = @tasks
+      .order(:level, :trader, :name)
+      .page(params[:page])
+      .per(20)
+
+    set_trader_options
+  end
+
+  def new
+    @task = Task.new(level: 1)
+    set_trader_options
+  end
+
+  def create
+    @task = Task.new(task_params)
+
+    if @task.save
+      redirect_to edit_admin_task_path(@task), notice: "タスクを追加しました。続けて必要アイテムを追加してください。"
+    else
+      set_trader_options
+      flash.now[:alert] = "タスクの追加に失敗しました。入力内容を確認してください。"
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def edit
+    @task = Task.find(params[:id])
+    set_trader_options
+    set_item_task_records
+    set_available_items
+  end
+
+  def update
+    @task = Task.find(params[:id])
+
+    ActiveRecord::Base.transaction do
+      @task.update!(task_params)
+      update_item_tasks
+      add_item_task
+    end
+
+    redirect_to edit_admin_task_path(@task), notice: "タスク情報を更新しました。"
+  rescue ActiveRecord::RecordInvalid
+    set_trader_options
+    set_item_task_records
+    set_available_items
+    flash.now[:alert] = "タスク情報の更新に失敗しました。入力内容を確認してください。"
+    render :edit, status: :unprocessable_content
+  end
+
+  private
+
+  def task_params
+    params.require(:task).permit(:name, :trader, :level, :description)
+  end
+
+  def set_trader_options
+    @traders = Task
+      .where.not(trader: [nil, ""])
+      .distinct
+      .order(:trader)
+      .pluck(:trader)
+  end
+
+  def set_item_task_records
+    @item_tasks = @task
+      .item_tasks
+      .includes(:item)
+      .joins(:item)
+      .order("items.name ASC")
+  end
+
+  def set_available_items
+    @item_q = params[:item_q].to_s.strip
+
+    @available_items = Item
+      .where.not(id: @task.item_tasks.select(:item_id))
+      .search_by_name(@item_q)
+      .order(:name)
+  end
+
+  def update_item_tasks
+    delete_ids = Array(params[:delete_item_task_ids]).map(&:to_i)
+    @task.item_tasks.where(id: delete_ids).destroy_all if delete_ids.any?
+
+    quantity_params = params[:item_task_required_quantities]
+    return if quantity_params.blank?
+
+    @task.item_tasks.where(id: quantity_params.keys).find_each do |item_task|
+      next if delete_ids.include?(item_task.id)
+
+      item_task.update!(required_quantity: quantity_params[item_task.id.to_s])
+    end
+  end
+
+  def add_item_task
+    item_name = params[:new_item_name].to_s.strip
+    return if item_name.blank?
+
+    item = Item.find_by(name: item_name)
+
+    unless item
+      @task.errors.add(:base, "追加するアイテムは候補から選択してください。")
+      raise ActiveRecord::RecordInvalid, @task
+    end
+
+    required_quantity = params[:new_required_quantity].presence || 1
+
+    item_task = @task.item_tasks.find_or_initialize_by(item: item)
+    item_task.required_quantity = required_quantity
+    item_task.save!
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,14 +1,38 @@
-<div class="detail-card">
+<div class="admin-card">
   <h1 class="detail-title">管理画面</h1>
 
-  <p class="detail-label">管理者専用ページです。</p>
+  <p class="admin-description">
+    アイテムやタスクなど、アプリで使用する基本データを管理できます。
+  </p>
 
-  <div class="detail-box">
-    <p>管理者向け機能をここから利用できます。</p>
+  <div class="admin-menu-grid">
+    <div class="admin-menu-card">
+      <h2 class="admin-menu-title">アイテム管理</h2>
+      <p class="admin-menu-text">
+        アイテム名や詳細説明を編集できます。新しく必要になったアイテムも追加できます。
+      </p>
+      <p><%= link_to "アイテムを管理する", admin_items_path, class: "admin-menu-button" %></p>
+      <p><%= link_to "アイテムを追加する", new_admin_item_path, class: "admin-menu-button" %></p>
+    </div>
+
+    <div class="admin-menu-card">
+      <h2 class="admin-menu-title">タスク管理</h2>
+      <p class="admin-menu-text">
+        タスク名、トレーダー、必要レベル、説明文、必要アイテムを管理できます。新しく追加されたタスクも登録できます。
+      </p>
+      <p><%= link_to "タスクを管理する", admin_tasks_path, class: "admin-menu-button" %></p>
+      <p><%= link_to "タスクを追加する", new_admin_task_path, class: "admin-menu-button" %></p>
+    </div>
   </div>
 
-  <div class="field" style="margin-top: 16px;">
-    <p><%= link_to "アイテム編集", admin_items_path %></p>
-    <p><%= link_to "アイテム一覧に戻る", items_path %></p>
+  <div class="detail-box admin-note-box">
+    <p>
+      タルコフ側で必要アイテムやタスク内容が変更された場合は、管理者画面から現在のマスターデータを更新できます。
+    </p>
+  </div>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "通常画面へ戻る", root_path %></p>
+    <p><%= link_to "アイテム一覧へ戻る", items_path %></p>
   </div>
 </div>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,8 +1,9 @@
-<div class="admin-form-card">
+cat > app/views/admin/items/edit.html.erb <<'EOF'
+<div class="admin-form-card admin-item-edit-card">
   <h1 class="detail-title">アイテム編集</h1>
 
   <p class="admin-description">
-    アイテム名と詳細説明を編集できます。
+    アイテム名、詳細説明、タスク・ハイドアウトで必要な個数を編集できます。
   </p>
 
   <%= form_with model: [:admin, @item], local: true do |f| %>
@@ -17,14 +18,90 @@
       </div>
     <% end %>
 
-    <div class="field admin-form-field">
-      <%= f.label :name, "アイテム名" %><br>
-      <%= f.text_field :name, class: "admin-text-field" %>
+    <div class="admin-edit-section">
+      <h2 class="admin-section-title">基本情報</h2>
+
+      <div class="field admin-form-field">
+        <%= f.label :name, "アイテム名" %><br>
+        <%= f.text_field :name, class: "admin-text-field" %>
+      </div>
+
+      <div class="field admin-form-field">
+        <%= f.label :description, "詳細説明" %><br>
+        <%= f.text_area :description, rows: 8, class: "admin-text-area", placeholder: "アイテムの説明や補足情報を入力してください" %>
+      </div>
     </div>
 
-    <div class="field admin-form-field">
-      <%= f.label :description, "詳細説明" %><br>
-      <%= f.text_area :description, rows: 8, class: "admin-text-area", placeholder: "アイテムの説明や補足情報を入力してください" %>
+    <div class="admin-edit-section">
+      <h2 class="admin-section-title">タスクで必要な個数</h2>
+
+      <% if @item_tasks.any? %>
+        <table class="admin-items-table admin-quantity-table">
+          <thead>
+            <tr>
+              <th>タスク名</th>
+              <th>トレーダー</th>
+              <th>必要レベル</th>
+              <th>必要個数</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @item_tasks.each do |item_task| %>
+              <tr>
+                <td class="admin-item-name"><%= item_task.task.name %></td>
+                <td><%= item_task.task.trader %></td>
+                <td>Lv.<%= item_task.task.level %></td>
+                <td>
+                  <%= number_field_tag "item_task_required_quantities[#{item_task.id}]",
+                                       item_task.required_quantity,
+                                       min: 0,
+                                       class: "admin-required-quantity-field" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-muted">このアイテムはタスクでは使用されていません。</p>
+      <% end %>
+    </div>
+
+    <div class="admin-edit-section">
+      <h2 class="admin-section-title">ハイドアウトで必要な個数</h2>
+
+      <% if @item_hideouts.any? %>
+        <table class="admin-items-table admin-quantity-table">
+          <thead>
+            <tr>
+              <th>ハイドアウト名</th>
+              <th>必要個数</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @item_hideouts.each do |item_hideout| %>
+              <tr>
+                <td class="admin-item-name"><%= item_hideout.hideout.name %></td>
+                <td>
+                  <%= number_field_tag "item_hideout_required_quantities[#{item_hideout.id}]",
+                                       item_hideout.required_quantity,
+                                       min: 0,
+                                       class: "admin-required-quantity-field" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-muted">このアイテムはハイドアウトでは使用されていません。</p>
+      <% end %>
+    </div>
+
+    <div class="detail-box admin-note-box">
+      <p>
+        必要個数を変更すると、アイテム一覧・不足アイテム一覧・アイテム詳細で表示される必要数にも反映されます。
+      </p>
     </div>
 
     <div class="actions">
@@ -37,3 +114,4 @@
     <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
   </div>
 </div>
+EOF

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -5,16 +5,16 @@
     登録されているアイテム情報を編集できます。
   </p>
 
-  <div class="admin-search-area">
-    <%= form_with url: admin_items_path, method: :get, local: true do %>
-      <div class="field">
-        <%= label_tag :q, "アイテム名で検索" %>
-      </div>
+  <div class="admin-page-actions">
+    <%= link_to "アイテムを追加する", new_admin_item_path, class: "admin-menu-button" %>
+  </div>
 
-      <div class="admin-search-form">
-        <%= text_field_tag :q, @q, placeholder: "アイテム名" %>
-        <%= submit_tag "検索", class: "simple-button" %>
-      </div>
+  <div class="admin-search-area">
+    <%= form_with url: admin_items_path, method: :get, local: true, class: "admin-search-form" do %>
+      <%= label_tag :q, "アイテム名で検索" %>
+      <%= text_field_tag :q, @q, placeholder: "アイテム名" %>
+      <%= submit_tag "検索", class: "simple-button" %>
+      <%= link_to "検索をクリア", admin_items_path, class: "simple-button" %>
     <% end %>
   </div>
 
@@ -23,7 +23,7 @@
       <thead>
         <tr>
           <th>アイテム名</th>
-          <th>詳細</th>
+          <th>詳細説明</th>
           <th class="admin-action-column">操作</th>
         </tr>
       </thead>
@@ -39,7 +39,7 @@
               <% if item.description.present? %>
                 <%= truncate(item.description, length: 80) %>
               <% else %>
-                <span class="login-guide">未登録</span>
+                <span class="text-muted">未設定</span>
               <% end %>
             </td>
 

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,0 +1,47 @@
+<div class="admin-form-card">
+  <h1 class="detail-title">アイテム追加</h1>
+
+  <p class="admin-description">
+    新しく必要になったアイテムを追加できます。
+    追加後、タスク編集画面から必要アイテムとして紐付けてください。
+  </p>
+
+  <%= form_with model: [:admin, @item], local: true do |f| %>
+    <% if @item.errors.any? %>
+      <div class="flash-message alert">
+        <p><%= @item.errors.count %>件のエラーがあります。</p>
+        <ul>
+          <% @item.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="field admin-form-field">
+      <%= f.label :name, "アイテム名" %><br>
+      <%= f.text_field :name, class: "admin-text-field", placeholder: "例: Corrugated hose" %>
+    </div>
+
+    <div class="field admin-form-field">
+      <%= f.label :description, "詳細説明" %><br>
+      <%= f.text_area :description, rows: 8, class: "admin-text-area", placeholder: "アイテムの説明や補足情報を入力してください" %>
+    </div>
+
+    <div class="detail-box admin-note-box">
+      <p>
+        アイテムを追加しただけでは、必要数には反映されません。
+        タスク編集画面で必要アイテムとして追加すると、必要数に反映されます。
+      </p>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "追加する", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "管理者用アイテム一覧へ戻る", admin_items_path %></p>
+    <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
+  </div>
+</div>

--- a/app/views/admin/tasks/edit.html.erb
+++ b/app/views/admin/tasks/edit.html.erb
@@ -1,0 +1,167 @@
+<div class="admin-form-card admin-task-edit-card">
+  <h1 class="detail-title">タスク編集</h1>
+
+  <p class="admin-description">
+    タスク名、トレーダー、必要レベル、説明文、必要アイテムを編集できます。
+  </p>
+
+  <div class="admin-edit-section">
+    <h2 class="admin-section-title">追加候補アイテムを検索</h2>
+
+    <p class="admin-description">
+      追加したいアイテムが多い場合は、ここでアイテム名を検索すると候補を絞り込めます。
+    </p>
+
+    <%= form_with url: edit_admin_task_path(@task), method: :get, local: true do %>
+      <div class="admin-search-form">
+        <%= label_tag :item_q, "アイテム名検索" %>
+        <%= text_field_tag :item_q, @item_q, placeholder: "例: hose / key / salewa" %>
+        <%= submit_tag "検索", class: "simple-button" %>
+        <%= link_to "検索をクリア", edit_admin_task_path(@task), class: "simple-button" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= form_with model: [:admin, @task], local: true do |f| %>
+    <% if @task.errors.any? %>
+      <div class="flash-message alert">
+        <p><%= @task.errors.count %>件のエラーがあります。</p>
+        <ul>
+          <% @task.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="admin-edit-section">
+      <h2 class="admin-section-title">基本情報</h2>
+
+      <div class="field admin-form-field">
+        <%= f.label :name, "タスク名" %><br>
+        <%= f.text_field :name, class: "admin-text-field" %>
+      </div>
+
+      <div class="field admin-form-field">
+        <%= f.label :trader, "トレーダー" %><br>
+        <%= f.text_field :trader,
+                         list: "trader-options",
+                         class: "admin-text-field",
+                         placeholder: "文字を入力すると候補が表示されます" %>
+
+        <datalist id="trader-options">
+          <% @traders.each do |trader| %>
+            <option value="<%= trader %>"></option>
+          <% end %>
+        </datalist>
+      </div>
+
+      <div class="field admin-form-field">
+        <%= f.label :level, "必要レベル" %><br>
+        <%= f.number_field :level, min: 1, class: "admin-number-field" %>
+      </div>
+
+      <div class="field admin-form-field">
+        <%= f.label :description, "説明文" %><br>
+        <%= f.text_area :description, rows: 8, class: "admin-text-area", placeholder: "タスクの説明や補足情報を入力してください" %>
+      </div>
+    </div>
+
+    <div class="admin-edit-section">
+      <h2 class="admin-section-title">現在の必要アイテム</h2>
+
+      <% if @item_tasks.any? %>
+        <table class="admin-items-table admin-quantity-table">
+          <thead>
+            <tr>
+              <th>アイテム名</th>
+              <th>必要個数</th>
+              <th>削除</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <% @item_tasks.each do |item_task| %>
+              <tr>
+                <td class="admin-item-name">
+                  <%= item_task.item.name %>
+                </td>
+
+                <td>
+                  <%= number_field_tag "item_task_required_quantities[#{item_task.id}]",
+                                       item_task.required_quantity,
+                                       min: 0,
+                                       class: "admin-required-quantity-field" %>
+                </td>
+
+                <td>
+                  <label class="admin-delete-check-label">
+                    <%= check_box_tag "delete_item_task_ids[]", item_task.id, false %>
+                    削除する
+                  </label>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-muted">このタスクに必要アイテムは登録されていません。</p>
+      <% end %>
+    </div>
+
+    <div class="admin-edit-section">
+      <h2 class="admin-section-title">必要アイテムを追加</h2>
+
+      <p class="admin-description">
+        アイテム名を入力すると候補が表示されます。候補から選択して、必要個数を入力してください。
+      </p>
+
+      <div class="admin-add-item-grid">
+        <div class="field">
+          <%= label_tag :new_item_name, "追加するアイテム" %><br>
+          <%= text_field_tag :new_item_name,
+                             "",
+                             list: "available-items",
+                             placeholder: "アイテム名を入力して候補から選択",
+                             class: "admin-text-field admin-add-item-name-field" %>
+
+          <datalist id="available-items">
+            <% @available_items.each do |item| %>
+              <option value="<%= item.name %>"></option>
+            <% end %>
+          </datalist>
+
+          <% if @available_items.empty? %>
+            <p class="text-muted" style="margin-top: 8px;">
+              追加できるアイテムがありません。
+            </p>
+          <% else %>
+            <p class="text-muted" style="margin-top: 8px;">
+              表示候補: <%= @available_items.size %>件
+            </p>
+          <% end %>
+        </div>
+
+        <div class="field">
+          <%= label_tag :new_required_quantity, "必要個数" %><br>
+          <%= number_field_tag :new_required_quantity, 1, min: 0, class: "admin-required-quantity-field" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="detail-box admin-note-box">
+      <p>
+        必要アイテムや必要個数を変更すると、アイテム一覧・不足アイテム一覧・タスク詳細で表示される必要数にも反映されます。
+      </p>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "更新する", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "管理者用タスク一覧へ戻る", admin_tasks_path %></p>
+    <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
+  </div>
+</div>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,0 +1,84 @@
+<div class="admin-card">
+  <h1 class="detail-title">管理者用タスク一覧</h1>
+
+  <p class="admin-description">
+    登録されているタスク情報を編集できます。
+  </p>
+
+  <div class="admin-page-actions">
+    <%= link_to "タスクを追加する", new_admin_task_path, class: "admin-menu-button" %>
+  </div>
+
+  <div class="admin-search-area">
+    <%= form_with url: admin_tasks_path, method: :get, local: true do %>
+      <div class="admin-filter-grid">
+        <div class="field">
+          <%= label_tag :q, "タスク名で検索" %><br>
+          <%= text_field_tag :q, @q, placeholder: "タスク名", class: "admin-text-field" %>
+        </div>
+
+        <div class="field">
+          <%= label_tag :trader, "トレーダーで絞り込み" %><br>
+          <%= select_tag :trader,
+                         options_for_select([["すべて", ""]] + @traders.map { |trader| [trader, trader] }, @trader),
+                         class: "admin-select-field" %>
+        </div>
+
+        <div class="field admin-filter-action">
+          <%= submit_tag "絞り込む", class: "simple-button" %>
+          <%= link_to "検索をクリア", admin_tasks_path, class: "simple-button" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @tasks.any? %>
+    <table class="admin-items-table">
+      <thead>
+        <tr>
+          <th>タスク名</th>
+          <th>トレーダー</th>
+          <th>必要レベル</th>
+          <th>関連アイテム数</th>
+          <th class="admin-action-column">操作</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @tasks.each do |task| %>
+          <tr>
+            <td class="admin-item-name">
+              <%= task.name %>
+            </td>
+
+            <td>
+              <%= task.trader %>
+            </td>
+
+            <td>
+              Lv.<%= task.level %>
+            </td>
+
+            <td>
+              <%= task.items.size %>件
+            </td>
+
+            <td class="admin-action-column">
+              <%= link_to "編集", edit_admin_task_path(task), class: "admin-edit-button" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <div class="pagination-area">
+      <%= paginate @tasks %>
+    </div>
+  <% else %>
+    <p style="margin-top: 24px;">該当するタスクがありません。</p>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
+  </div>
+</div>

--- a/app/views/admin/tasks/new.html.erb
+++ b/app/views/admin/tasks/new.html.erb
@@ -1,0 +1,69 @@
+<div class="admin-form-card">
+  <h1 class="detail-title">タスク追加</h1>
+
+  <p class="admin-description">
+    新しく追加されたタスクを登録できます。
+    登録後、必要アイテムを追加する編集画面へ移動します。
+  </p>
+
+  <%= form_with model: [:admin, @task], local: true do |f| %>
+    <% if @task.errors.any? %>
+      <div class="flash-message alert">
+        <p><%= @task.errors.count %>件のエラーがあります。</p>
+        <ul>
+          <% @task.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="field admin-form-field">
+      <%= f.label :name, "タスク名" %><br>
+      <%= f.text_field :name, class: "admin-text-field", placeholder: "例: Debut" %>
+    </div>
+
+    <div class="field admin-form-field">
+      <%= f.label :trader, "トレーダー" %><br>
+      <%= f.text_field :trader,
+                       list: "trader-options",
+                       class: "admin-text-field",
+                       placeholder: "文字を入力すると候補が表示されます" %>
+
+      <datalist id="trader-options">
+        <% @traders.each do |trader| %>
+          <option value="<%= trader %>"></option>
+        <% end %>
+      </datalist>
+
+      <p class="text-muted" style="margin-top: 8px;">
+        既存のトレーダー名は候補から選択できます。新しいトレーダー名を直接入力することもできます。
+      </p>
+    </div>
+
+    <div class="field admin-form-field">
+      <%= f.label :level, "必要レベル" %><br>
+      <%= f.number_field :level, min: 1, value: @task.level || 1, class: "admin-number-field" %>
+    </div>
+
+    <div class="field admin-form-field">
+      <%= f.label :description, "説明文" %><br>
+      <%= f.text_area :description, rows: 8, class: "admin-text-area", placeholder: "タスクの説明や補足情報を入力してください" %>
+    </div>
+
+    <div class="detail-box admin-note-box">
+      <p>
+        タスク追加後、編集画面で必要アイテムを検索して追加できます。
+      </p>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "追加する", class: "header-button" %>
+    </div>
+  <% end %>
+
+  <div class="field" style="margin-top: 24px;">
+    <p><%= link_to "管理者用タスク一覧へ戻る", admin_tasks_path %></p>
+    <p><%= link_to "管理画面へ戻る", admin_root_path %></p>
+  </div>
+</div>

--- a/app/views/deficit_items/index.html.erb
+++ b/app/views/deficit_items/index.html.erb
@@ -3,6 +3,7 @@
 
   <p style="margin-bottom: 24px; line-height: 1.8;">
     必要数に対して所持数が足りていないアイテムを一覧で確認できます。
+    不足しているアイテムは赤で表示されます。
   </p>
 
   <div class="field" style="margin-bottom: 24px;">
@@ -12,44 +13,60 @@
       </div>
       <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
         <%= select_tag :sort, options_for_select(@sort_options, @selected_sort) %>
-        <%= submit_tag "適用" %>
+        <%= submit_tag "適用", class: "simple-button" %>
       </div>
     <% end %>
   </div>
 
   <% if @deficit_items.any? %>
-    <table style="width: 100%; border-collapse: collapse; margin-top: 16px;">
+    <table class="items-table">
       <thead>
         <tr>
-          <th style="text-align: left; padding: 14px 10px; border-bottom: 1px solid #ccc;">アイテム名</th>
-          <th style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #ccc;">必要数</th>
-          <th style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #ccc;">所持数</th>
-          <th style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #ccc;">不足数</th>
+          <th>アイテム名</th>
+          <th style="text-align: right;">必要数</th>
+          <th style="text-align: right;">所持数</th>
+          <th style="text-align: right;">不足数</th>
+          <th>状態</th>
         </tr>
       </thead>
+
       <tbody>
         <% @deficit_items.each do |item| %>
           <% user_item = @user_items_by_item_id[item.id] %>
           <% owned_quantity = user_item&.quantity.to_i %>
+          <% deficit_quantity = item.deficit_quantity_for(current_user) %>
+
           <tr>
-            <td style="padding: 14px 10px; border-bottom: 1px solid #eee; line-height: 1.6;">
+            <td>
               <%= link_to item.name, item_path(item) %>
             </td>
-            <td style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #eee;">
+
+            <td style="text-align: right;">
               <%= item.total_required_quantity %>
             </td>
-            <td style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #eee;">
+
+            <td style="text-align: right;">
               <%= owned_quantity %>
             </td>
-            <td style="text-align: right; padding: 14px 10px; border-bottom: 1px solid #eee; font-weight: bold;">
-              <%= item.deficit_quantity_for(current_user) %>
+
+            <td style="text-align: right; font-weight: bold;">
+              <span class="status-text-danger"><%= deficit_quantity %></span>
+            </td>
+
+            <td>
+              <span class="status-badge-danger">まだ必要</span>
             </td>
           </tr>
         <% end %>
       </tbody>
     </table>
   <% else %>
-    <p style="margin-top: 24px;">不足しているアイテムはありません。</p>
+    <div class="detail-box">
+      <p>
+        <span class="status-badge-success">達成</span>
+        不足しているアイテムはありません。
+      </p>
+    </div>
   <% end %>
 
   <div class="field" style="margin-top: 24px;">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,66 +1,77 @@
-<div class="page-header">
-  <h1>タスク一覧</h1>
-</div>
+<div class="detail-card" style="max-width: 960px;">
+  <h1 class="detail-title">タスク一覧</h1>
 
-<div class="search-form">
-  <%= form_with url: tasks_path, method: :get, local: true do %>
-    <div class="field">
-      <%= label_tag :trader, "トレーダーで絞り込み" %>
-      <%= select_tag :trader,
-          options_for_select([["すべて", ""]] + @traders.map { |trader| [trader, trader] }, @selected_trader) %>
-    </div>
+  <p class="admin-description">
+    タスクの確認と進行状況の管理ができます。完了済みのタスクは緑、未完了のタスクは赤で表示されます。
+  </p>
 
-    <div class="field">
-      <%= label_tag :level, "必要レベルで絞り込み" %>
-      <%= select_tag :level,
-          options_for_select([["すべて", ""]] + @levels.map { |level| ["Lv#{level}", level] }, @selected_level) %>
-    </div>
+  <div class="search-area">
+    <%= form_with url: tasks_path, method: :get, local: true do %>
+      <div class="admin-filter-grid">
+        <div class="field">
+          <%= label_tag :trader, "トレーダーで絞り込み" %><br>
+          <%= select_tag :trader,
+              options_for_select([["すべて", ""]] + @traders.map { |trader| [trader, trader] }, @selected_trader),
+              class: "admin-select-field" %>
+        </div>
 
-    <div class="field">
-      <%= label_tag :status, "進行状況で絞り込み" %>
-      <%= select_tag :status,
-          options_for_select([["すべて", ""], ["完了", "completed"], ["未完了", "incomplete"]], @selected_status) %>
-    </div>
+        <div class="field">
+          <%= label_tag :level, "必要レベルで絞り込み" %><br>
+          <%= select_tag :level,
+              options_for_select([["すべて", ""]] + @levels.map { |level| ["Lv#{level}", level] }, @selected_level),
+              class: "admin-select-field" %>
+        </div>
 
-    <div class="field">
-      <%= submit_tag "絞り込む", class: "header-button" %>
-    </div>
+        <div class="field">
+          <%= label_tag :status, "進行状況で絞り込み" %><br>
+          <%= select_tag :status,
+              options_for_select([["すべて", ""], ["完了", "completed"], ["未完了", "incomplete"]], @selected_status),
+              class: "admin-select-field" %>
+        </div>
+
+        <div class="field admin-filter-action">
+          <%= submit_tag "絞り込む", class: "header-button" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @tasks.any? %>
+    <table class="items-table">
+      <thead>
+        <tr>
+          <th>タスク名</th>
+          <th>トレーダー</th>
+          <th>必要レベル</th>
+          <th>進行状況</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @tasks.each do |task| %>
+          <% user_task = @user_tasks_by_task_id[task.id] %>
+          <% completed = user_task&.completed || false %>
+
+          <tr>
+            <td class="task-name"><%= link_to task.name, task_path(task) %></td>
+            <td><%= task.trader %></td>
+            <td>Lv.<%= task.level %></td>
+            <td>
+              <% if user_signed_in? %>
+                <%= form_with url: user_task_path(task_id: task.id, trader: @selected_trader, level: @selected_level, status: @selected_status), method: :patch, local: true do |f| %>
+                  <%= f.hidden_field :completed, value: completed ? "0" : "1", name: "user_task[completed]" %>
+                  <%= f.submit(completed ? "完了済み" : "未完了",
+                               class: completed ? "status-button-success" : "status-button-danger") %>
+                <% end %>
+              <% else %>
+                <span class="status-badge-danger">ログインしてください</span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>該当するタスクがありません。</p>
   <% end %>
 </div>
-
-<% if @tasks.any? %>
-  <table class="items-table">
-    <thead>
-      <tr>
-        <th>タスク名</th>
-        <th>トレーダー</th>
-        <th>必要レベル</th>
-        <th>進行状況</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @tasks.each do |task| %>
-        <% user_task = @user_tasks_by_task_id[task.id] %>
-        <% completed = user_task&.completed || false %>
-
-        <tr>
-          <td><%= link_to task.name, task_path(task) %></td>
-          <td><%= task.trader %></td>
-          <td><%= task.level %></td>
-          <td>
-            <% if user_signed_in? %>
-              <%= form_with url: user_task_path(task_id: task.id, trader: @selected_trader, level: @selected_level, status: @selected_status), method: :patch, local: true do |f| %>
-                <%= f.hidden_field :completed, value: completed ? "0" : "1", name: "user_task[completed]" %>
-                <%= f.submit(completed ? "完了" : "未完了", class: "simple-button") %>
-              <% end %>
-            <% else %>
-              ログインしてください
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p>該当するタスクがありません。</p>
-<% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,8 +1,17 @@
 <div class="detail-card">
   <h1 class="detail-title"><%= @task.name %></h1>
 
+  <p class="detail-label">トレーダー: <%= @task.trader %></p>
+  <p class="detail-label">必要レベル: Lv.<%= @task.level %></p>
   <p class="detail-label">必要アイテム数: <%= @task.item_tasks.count %>件</p>
   <p class="detail-label">必要個数合計: <%= @task.item_tasks.sum(:required_quantity) %>個</p>
+
+  <% if @task.description.present? %>
+    <div class="detail-box detail-description-box">
+      <p class="detail-label">説明</p>
+      <%= simple_format(@task.description) %>
+    </div>
+  <% end %>
 
   <p class="detail-label">必要アイテム一覧</p>
   <div class="detail-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ Rails.application.routes.draw do
   namespace :admin do
     root "dashboard#index"
     get "dashboard", to: "dashboard#index"
-    resources :items, only: %i[index edit update]
+    resources :items, only: %i[index new create edit update]
+    resources :tasks, only: %i[index new create edit update]
   end
 
   if Rails.env.development?

--- a/db/migrate/20260516113945_add_description_to_tasks.rb
+++ b/db/migrate/20260516113945_add_description_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToTasks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :tasks, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_14_182918) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_16_113945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_14_182918) do
     t.datetime "updated_at", null: false
     t.string "trader"
     t.integer "level", default: 1, null: false
+    t.text "description"
   end
 
   create_table "user_items", force: :cascade do |t|


### PR DESCRIPTION
## 概要
管理画面のUI/UXを改善し、タスク・アイテムなどのマスターデータを管理者が追加・編集できるようにしました。

## 変更内容
- 管理画面トップを管理メニュー形式に変更
- 管理者用タスク一覧・編集画面を追加
- 管理者用アイテム追加画面を追加
- 管理者用タスク追加画面を追加
- タスクに説明文を登録できるように変更
- タスク編集画面で必要アイテムの追加・削除・必要個数変更に対応
- アイテム編集画面でタスク・ハイドアウトごとの必要個数変更に対応
- タスク追加・編集時にトレーダー候補を表示
- タスク一覧の完了/未完了ボタンを色分け
- 不足アイテム一覧の状態表示を色分け
- 管理画面・一覧画面のUIを調整

## 確認項目
- `bin/rails zeitwerk:check` が通る
- `bin/rails db:migrate:status` で `Add description to tasks` が `up` になっている
- 管理画面からアイテム管理・タスク管理へ遷移できる
- アイテムを新規追加できる
- タスクを新規追加できる
- タスク追加後にタスク編集画面へ遷移する
- タスク編集画面で必要アイテムを検索して追加できる
- タスク編集画面で必要アイテムの個数変更・削除ができる
- タスク一覧で完了済みが緑、未完了が赤で表示される
- 不足アイテム一覧で不足状態が赤で表示される

Closes #64